### PR TITLE
Apply correct precedence on AND and OR in ops_gen_rcp.

### DIFF
--- a/ops_gen_rcp.f90
+++ b/ops_gen_rcp.f90
@@ -237,7 +237,8 @@ ELSE
     
     ! Check data on data line: 
     IF (ierr == 0) THEN
-       IF (z0 > 0 .and. (nwords == 15 .or. nwords == 16) .and. sum(lu_rcp_per_user(1:NLU)) .lt. 99 .or. sum(lu_rcp_per_user(1:NLU)) .gt. 101) THEN
+       IF (z0 > 0 .and. (nwords == 15 .or. nwords == 16) .and.  &
+          ( sum(lu_rcp_per_user(1:NLU)) .lt. 99 .or. sum(lu_rcp_per_user(1:NLU)) .gt. 101)) THEN
           CALL SetError('INPUT ERROR: No correct input in receptorfile', error)
           CALL ErrorParam('filename', namrecept, error)
           CALL ErrorParam('record number', i + h, error)
@@ -311,7 +312,8 @@ ELSE
         CALL ErrorParam('nwords read from rcp-file should be:', nwords, error)
         GOTO 9999
       ENDIF
-      IF (z0 > 0.0 .AND. ierr == 0 .AND. (nwords == 15 .or. nwords == 16) .AND. sum(lu_rcp_per_user(1:NLU)) .lt. 99 .or. sum(lu_rcp_per_user(1:NLU)) .gt. 101) THEN
+      IF (z0 > 0.0 .AND. ierr == 0 .AND. (nwords == 15 .or. nwords == 16) .AND.  &
+         ( sum(lu_rcp_per_user(1:NLU)) .lt. 99 .or. sum(lu_rcp_per_user(1:NLU)) .gt. 101)) THEN
         CALL SetError('INPUT ERROR: No correct input in receptorfile', error)
         CALL ErrorParam('filename', namrecept, error)
         CALL ErrorParam('record number', i + h, error)


### PR DESCRIPTION
It seems that the GNU Fortan compiler sometimes returns value larger than 101, whereas the Intel Fortran compiler sometimes uses a value smaller than 101. The precedence bug does not currently seem to have an impact since land use is read from a file.

Changes developed by Gerard Cats.