### PR TITLE
Replace mixed use of real and real*4 by solely the more portable real data type.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,9 @@
+OPS (Operationele Prioritaire Stoffen) is een rekenprogramma om de verspreiding van verontreinigende stoffen in de lucht te simuleren.
+Daarnaast berekent het model hoeveel van die stoffen per hectare op bodem of gewas terechtkomt (depositie).
+Het model wordt sinds 1989 gebruikt om de relatie tussen de uitstoot van stoffen in Europa enerzijds en de concentratie of depositie van die stoffen anderzijds op de schaal van Nederland te bepalen.
+
+Meer informatie en een uitgebreide documentatie van de werking van het model vindt u op www.rivm.nl/ops.
+
+Een Windows-executable van OPS + Grafische User Interface om invoerbestanden voor OPS te genereren is te downloaden via dezelfde website.
+
+Voor instructies voor het zelf compileren van de source code kunt u contact opnemen met OPS-support@rivm.nl.

--- a/binas.f90
+++ b/binas.f90
@@ -1,35 +1,31 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
-!-------------------------------------------------------------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 module Binas
 
   implicit none
-
+  
   public
-
+  
   !
   !ProTeX: 1.14-AJS
   !
   !BOI
   !
   ! !TITLE:        Binas - geometrical and physical constants
-  ! !AUTHORS:      Arjo Segers
+  ! !AUTHORS:       
   ! !AFFILIATION:  KNMI
   ! !DATE:         \today
   !
@@ -46,16 +42,16 @@ module Binas
   ! ---------------------------------------------------------------
   ! gonio
   ! ---------------------------------------------------------------
-
+  
   ! defintions for pi :
   !  o old definition:
   !real, parameter         ::  pi    = 3.1415927
   !  o EMOS definition (emos/interpolation/strlat.F, parameter PPI)
   real, parameter         ::  pi = 3.14159265358979
 
-  ! two pi :
+  ! two pi :  
   real, parameter         ::  twopi = 2*pi
-
+  
   ! factors to convert to radians from degrees and the otrher way around;
   ! alpha_deg = alpha_rad*rad2deg
   ! alpha_rad = alpha_deg*deg2rad
@@ -66,7 +62,7 @@ module Binas
   ! ---------------------------------------------------------------
   ! earth
   ! ---------------------------------------------------------------
-
+  
   ! Radius of earth as used in EMOS library (ECMWF model),
   ! see for example "jvod2uv.F"
   ! NOTE: the value 6.375e6 was used in TM !
@@ -75,33 +71,33 @@ module Binas
   ! acceleration of gravity:
   !real, parameter         ::  grav = 9.81       ! m/s2
   real, parameter         ::  grav = 9.80665    ! m/s2
-
+  
   ! Earth's angular speed of rotation
   !  Omega =  2 * pi * (365.25/364.25) / (86400.0)
   real, parameter         ::  Omega = 7.292e-5    ! rad/s
 
-
+  
   ! ---------------------------------------------------------------
   ! molecules, mols, etc
   ! ---------------------------------------------------------------
-
+  
   ! Avogadro number
   real, parameter        ::  Avog = 6.02205e23      ! mlc/mol
-
+ 
   ! Dobson units:
   real,parameter         ::  Dobs = 2.68668e16    ! (mlc/cm2) / DU
-
+  
 
   !
   ! molar weights of components
-  !
-
+  ! 
+  
   ! naming convention:
   !  o old names 'xm***' are in g/mol
   !  o new names 'xm_***' are in kg/mol
   !
 
-  ! atomic weights:
+  ! atomic weights:  
   real, parameter        ::  xm_H     =    1.00790e-3     ! kg/mol
   real, parameter        ::  xm_N     =   14.00670e-3     ! kg/mol
   real, parameter        ::  xm_C     =   12.01115e-3     ! kg/mol
@@ -121,57 +117,57 @@ module Binas
   real, parameter        ::  xm_NH4   = xm_N + xm_O * 4         ! kg/mol
   real, parameter        ::  xm_SO4   = xm_S + xm_O * 4         ! kg/mol
   real, parameter        ::  xm_NO3   = xm_N + xm_O * 3         ! kg/mol
-
+  
   ! mass of air
   real, parameter        ::  xm_air   =  28.964e-3        ! kg/mol
   real, parameter        ::  xmair    =  28.94            ! g/mol; old name!
-
+  
   ! dummy weight, used for complex molecules:
   real, parameter        ::  xm_dummy =  1000.0e-3   ! kg/mol
 
   ! * seasalt
-
+  
   ! sesalt composition:
   ! (Seinfeld and Pandis, "Atmospheric Chemistry and Physics",
   !  table 7.8 "Composition of Sea-Salt", p. 444)
   real, parameter        ::  massfrac_Cl_in_seasalt  = 0.5504  ! (kg Cl )/(kg seasalt)
   real, parameter        ::  massfrac_Na_in_seasalt  = 0.3061  ! (kg Na )/(kg seasalt)
   real, parameter        ::  massfrac_SO4_in_seasalt = 0.0768  ! (kg SO4)/(kg seasalt)
-
+  
   ! other numbers (wikipedia ?)
   real, parameter         ::   xm_seasalt =  74.947e-3     ! kg/mol : NaCl, SO4, ..
   real, parameter         ::  rho_seasalt = 2.2e3 ! kg/m3
 
   ! * amonium sulphate
-
+  
   real, parameter         ::   xm_NH4HSO4  =  xm_NH4 + xm_H + xm_SO4  ! kg/mol
   real, parameter         ::  rho_NH4HSO4a = 1.8e3  ! kg/m3
 
-
+  
   !                  mlc/mol
   ! [cdob] = ------------------------ =   DU / (kg/m2)
   !          kg/mol cm2/m2 mlc/cm2/DU
   !
-
+  
   real, parameter :: cdob_o3 = Avog / ( xm_o3 * 1.0e4 * Dobs )  ! DU/(kg/m2)
-
+  
   ! ---------------------------------------------------------------
   ! gas
   ! ---------------------------------------------------------------
-
-  ! gas constant
+  
+  ! gas constant                        
   real, parameter        ::  Rgas = 8.3144     ! J/mol/K
-
+  
   ! gas constant for dry air
   !real, parameter        ::  rgas_x  = 287.05
   ! NEW:
   !   Rgas_air = Rgas / xmair = 287.0598
   real, parameter        ::  Rgas_air = Rgas / xm_air    ! J/kg/K
-
+  
   ! water vapour
   !real,parameter         ::  rgasv = 461.51
   real, parameter        ::  Rgas_h2o = Rgas / xm_h2o   ! J/kg/K
-
+  
   ! standard pressure
   real, parameter        ::  p0 = 1.0e5    ! Pa
   !real, parameter        ::  p0 = 1.01325e5    ! Pa  <-- suggestion Bram Bregman
@@ -189,7 +185,7 @@ module Binas
   ! Latent heat of condensation at 0 deg Celcius
   ! (heat (J) necesarry to evaporate 1 kg of water)
   real, parameter       ::  Lc = 22.6e5           ! J/kg
-
+  
   ! kappa = R/cp = 2/7
   real, parameter        ::  kappa = 2.0/7.0
   ! 'kapa' is probably 'kappa' ....
@@ -207,15 +203,15 @@ module Binas
 
   real, parameter        ::  eps  = Rgas_air / Rgas_h2o
   real, parameter        ::  eps1 = ( 1.0 - eps )/eps
-
-
+  
+  
   ! ---------------------------------------------------------------
   ! other
   ! ---------------------------------------------------------------
 
   ! melting point
   real, parameter        ::  T0 = 273.16    ! K
-
+  
   ! Rv/Rd
   real, parameter        ::  gamma = 6.5e-3
 
@@ -227,18 +223,18 @@ module Binas
 
   ! density of pure water at 15 deg C
   real, parameter                  ::  rho_water = 999.0     ! kg/m^3
-
+  
   ! density of dry air at 20 oC and 1013.25 hPa :
   real, parameter                  ::  rho_dry_air_20C_1013hPa = 1.2041 ! kg/m3
-
+  
   ! Planck times velocity of light
   real, parameter                  ::  hc = 6.626176e-34 * 2.997924580e8  ! Jm
-
-
+  
+  
   ! ---------------------------------------------------------------
   ! end
   ! ---------------------------------------------------------------
 
   !EOC
-
+  
 end module Binas

--- a/m_aps.f90
+++ b/m_aps.f90
@@ -56,14 +56,14 @@ IMPLICIT NONE
 ! Purpose    : Defines grid dimensions.
 !-------------------------------------------------------------------------------------------------------------------------------
 TYPE TGridHeader
-   REAL*4                                        :: xorgl                      ! x-origin of the grid [km]
+   real                                          :: xorgl                      ! x-origin of the grid [km]
                                                                                ! (origin is left-upper corner of grid)
-   REAL*4                                        :: yorgl                      ! y-origin of the grid [km]
+   real                                          :: yorgl                      ! y-origin of the grid [km]
                                                                                ! (origin is left-upper corner of grid)
    INTEGER*4                                     :: nrcol                      ! number of grid columns
    INTEGER*4                                     :: nrrow                      ! number of grid rows
-   REAL*4                                        :: grixl                      ! horizontal size of grid cell [km]
-   REAL*4                                        :: griyl                      ! vertical size of grid cell [km]
+   real                                          :: grixl                      ! horizontal size of grid cell [km]
+   real                                          :: griyl                      ! vertical size of grid cell [km]
 END TYPE TGridHeader
 
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -81,8 +81,8 @@ END TYPE TApsGridInt
 !-------------------------------------------------------------------------------------------------------------------------------
 TYPE TApsGridReal
    TYPE (TGridHeader)                            :: gridheader                 ! grid header
-   REAL*4, DIMENSION(:), POINTER                 :: average                    ! average of all grid values
-   REAL*4, DIMENSION(:,:,:), POINTER             :: value                      ! 3D array with real values
+   real,   DIMENSION(:), POINTER                 :: average                    ! average of all grid values
+   real,   DIMENSION(:,:,:), POINTER             :: value                      ! 3D array with real values
 END TYPE TApsGridReal
 
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -113,10 +113,10 @@ END INTERFACE
 ! DESCRIPTION : Returns value of grid cell with input coordinates.
 !               If coordinates outside grid, the average value (real grid) or 0 (integer) grid is returned. A flag, which
 !               indicates whether coordinates were inside the grid, is also returned.
-! INPUTS      : x          (real*4). RDM x-coordinate value (in km).
-!               y          (real*4). RDM y-coordinate value (in km).
+! INPUTS      : x          (real). RDM x-coordinate value (in km).
+!               y          (real). RDM y-coordinate value (in km).
 !               grid       (type TAPSGrid, generic) The aps grid definition.
-! OUTPUTS     : value      (integer*4 or real*4, generic with grid type)
+! OUTPUTS     : value      (integer*4 or real,   generic with grid type)
 !                          The value in the grid cell or the default value (in case of location outside grid)
 !               iscell     (logical) Whether value comes from a grid cell.
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ END INTERFACE
 ! SUBROUTINE  : SetAverage
 ! DESCRIPTION : Sets average field in aps grid structure. Average is calculated over all cells with value > 0. It is possible 
 !               to multiply all values by a certain factor first.
-! INPUTS      : factor     (real*4, optional). Multiplication factor.
+! INPUTS      : factor     (real,   optional). Multiplication factor.
 ! INPUT/OUTPUTS: grid      (TApsGridReal). The field grid.average is adjusted.
 !-------------------------------------------------------------------------------------------------------------------------------
 INTERFACE SetAverage
@@ -176,8 +176,8 @@ INTEGER*4                                        :: nrcol                      !
 INTEGER*4                                        :: nrrow                      ! number of grid rows
 INTEGER*4                                        :: ierr                       ! error status (ierr != 0 => error)
 CHARACTER*1                                      :: teststring                 ! helpvariable
-REAL*4                                           :: r                          ! helpvariable
-REAL*4, DIMENSION(:,:), ALLOCATABLE              :: helpgrid
+real                                             :: r                          ! helpvariable
+real,   DIMENSION(:,:), ALLOCATABLE              :: helpgrid
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! name of subroutine
@@ -509,7 +509,7 @@ SUBROUTINE set_average(factor, grid, fieldnumber)
 USE m_commonconst                                                              ! EPS_DELTA only
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN), OPTIONAL                  :: factor                     ! multiplication factor for the whole grid
+real,      INTENT(IN), OPTIONAL                  :: factor                     ! multiplication factor for the whole grid
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TApsGridReal), INTENT(INOUT)               :: grid                       ! real APS grid
@@ -549,8 +549,8 @@ SUBROUTINE grid_value_integer(x, y, grid, gridvalue, iscell, fieldnumber)
 !DEC$ ATTRIBUTES DLLEXPORT:: grid_value_integer
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: x                          ! RDM x-coordinate value (in km)
-REAL*4,    INTENT(IN)                            :: y                          ! RDM y-coordinate value (in km)
+real,      INTENT(IN)                            :: x                          ! RDM x-coordinate value (in km)
+real,      INTENT(IN)                            :: y                          ! RDM y-coordinate value (in km)
 TYPE (TAPSGridInt), INTENT(IN)                   :: grid                       ! integer APS grid
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
@@ -593,12 +593,12 @@ SUBROUTINE grid_value_real(x, y, grid, gridvalue, iscell, fieldnumber)
 !DEC$ ATTRIBUTES DLLEXPORT:: grid_value_real
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: x                          ! RDM x-coordinate value (in km)
-REAL*4,    INTENT(IN)                            :: y                          ! RDM y-coordinate value (in km)
+real,      INTENT(IN)                            :: x                          ! RDM x-coordinate value (in km)
+real,      INTENT(IN)                            :: y                          ! RDM y-coordinate value (in km)
 TYPE (TAPSGridReal), INTENT(IN)                  :: grid                       ! real APS grid
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: gridvalue                  ! the value in the grid cell or the default value 
+real,      INTENT(OUT)                           :: gridvalue                  ! the value in the grid cell or the default value
                                                                                ! (in case of location outside grid)
 LOGICAL,   INTENT(OUT)                           :: iscell                     ! whether value comes from a grid cell
 INTEGER, OPTIONAL, INTENT(IN)                    :: fieldnumber                ! fieldnumber to retreive data from
@@ -636,8 +636,8 @@ END SUBROUTINE grid_value_real
 SUBROUTINE grid_cell_index(x, y, gridheader, m, n, iscell)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: x                          ! RDM x-coordinate [km]
-REAL*4,    INTENT(IN)                            :: y                          ! RDM y-coordinate [km]
+real,      INTENT(IN)                            :: x                          ! RDM x-coordinate [km]
+real,      INTENT(IN)                            :: y                          ! RDM y-coordinate [km]
 TYPE (TGridHeader), INTENT(IN)                   :: gridheader                 ! Header definition of grid
 
 ! SUBROUTINE ARGUMENTS - OUTPUT

--- a/m_commonconst.f90
+++ b/m_commonconst.f90
@@ -65,38 +65,38 @@ INTEGER*4, PARAMETER                             :: NLU         = 9             
 INTEGER*4, PARAMETER                             :: ncolBuildingEffectTable = 5        ! 1st column corresponds to distance from building. 2-5 correspond to different building types
 
 ! CONSTANTS - overige
-REAL*4                                           :: z0_FACT_NL  = 10000.               ! default factor for conversion of z0_nl gridvalue to meters
-REAL*4                                           :: z0_FACT_EUR = 10000.               ! default factor for conversion of z0_eur gridvalue to meters
-                                                                                       
-REAL*4, PARAMETER                                :: zmet_T      = 1.5                  ! reference height for temperature measurements [m]
+real                                             :: z0_FACT_NL  = 10000.               ! default factor for conversion of z0_nl gridvalue to meters
+real                                             :: z0_FACT_EUR = 10000.               ! default factor for conversion of z0_eur gridvalue to meters
 
-INTEGER*4, PARAMETER                             :: IGEO        = 0                    ! 1 -> Geographical coordinates lon-lat [degrees]; 0 -> RDM coordinates [m]  
+real,   PARAMETER                                :: zmet_T      = 1.5                  ! reference height for temperature measurements [m]
+
+INTEGER*4, PARAMETER                             :: IGEO        = 0                    ! 1 -> Geographical coordinates lon-lat [degrees]; 0 -> RDM coordinates [m]
 INTEGER*4, PARAMETER                             :: MISVALNUM   = -9999                ! missing value
 INTEGER*4, PARAMETER                             :: FIRSTYEAR   = 1977                 ! first year, used for interpolating background maps
 INTEGER*4, PARAMETER                             :: FUTUREYEAR  = 2020                 ! future year, used for interpolating background maps
-REAL*4                                           :: r4_for_tiny                        ! help variable to define EPS_DELTA
-REAL*8                                           :: r8_for_tiny                        ! help variable to define DEPS_DELTA
-REAL*4,    PARAMETER                             :: EPS_DELTA   = tiny(r4_for_tiny)    ! tiny number (real)
-REAL*8,    PARAMETER                             :: DPEPS_DELTA = tiny(r8_for_tiny)    ! tiny number (double precision)
-REAL*4,    PARAMETER                             :: HUMAX       = 500.                 ! maximal plume height [m]      
+real                                             :: r4_for_tiny                        ! help variable to define EPS_DELTA
+double precision                                 :: r8_for_tiny                        ! help variable to define DEPS_DELTA
+real,      PARAMETER                             :: EPS_DELTA   = tiny(r4_for_tiny)    ! tiny number (real)
+double precision,    PARAMETER                   :: DPEPS_DELTA = tiny(r8_for_tiny)    ! tiny number (double precision)
+real,      PARAMETER                             :: HUMAX       = 500.                 ! maximal plume height [m]
 CHARACTER*8,  PARAMETER                          :: MODVERSIE   = '5.0.0.0'            ! model version OPS-LT
 CHARACTER*20, PARAMETER                          :: RELEASEDATE = '26 dec 2019'        ! release date
 
-!
+
 ! CONSTANTS - Data
-!
+
 INTEGER*4                                        :: NACHTZOMER(NSTAB, NTRAJ)           ! relative occurrences (%) of nighttime hours in summer (for each stability class and distance class) ("NACHT" = night, "ZOMER" = summer)
 INTEGER*4                                        :: NACHTWINTER(NSTAB, NTRAJ)          ! relative occurrences (%) of nighttime hours in winter (for each stability class and distance class) ("NACHT" = night)
-REAL*4                                           :: DISPH(NSTAB)                       ! coefficients for vertical dispersion coefficient sigma_z; sigma_z = dispg*x**disph  
-REAL*4                                           :: STOKES(NPARTCLASS)                 ! Sedimentation velocity (m/s) needed for plume descent in case of heavy particles, for each particle class
-REAL*4                                           :: SCWINTER(NSTAB)                    ! variation in NO2/NOx ratio (relative to stability class S2) for each stability class (only in winter)
-REAL*4                                           :: cf_so2(NBGMAPS)                    ! correction factors for the difference between model output and measurements for SO2
-REAL*4                                           :: cf_nox(NBGMAPS)                    ! correction factors for the difference between model output and measurements for NOx
-REAL*4                                           :: cf_nh3(NBGMAPS)                    ! correction factors for the difference between model output and measurements for NH3
-REAL*4                                           :: tf_so2(NYEARS + 1)                 ! trendfactors for SO2: concentration in year T, relative to the concentration in reference year
-REAL*4                                           :: tf_no2(NYEARS + 1)                 ! trendfactors for NO2: concentration in year T, relative to the concentration in reference year
-REAL*4                                           :: tf_nh3(NYEARS + 1)                 ! trendfactors for NH3: concentration in year T, relative to the concentration in reference year
-REAL*4                                           :: nox_no2_beta(2)                    ! coefficient in conversion NO2 = beta(1)*log(NOx) + beta(2)
+real                                             :: DISPH(NSTAB)                       ! coefficients for vertical dispersion coefficient sigma_z; sigma_z = dispg*x**disph
+real                                             :: STOKES(NPARTCLASS)                 ! Sedimentation velocity (m/s) needed for plume descent in case of heavy particles, for each particle class
+real                                             :: SCWINTER(NSTAB)                    ! variation in NO2/NOx ratio (relative to stability class S2) for each stability class (only in winter)
+real                                             :: cf_so2(NBGMAPS)                    ! correction factors for the difference between model output and measurements for SO2
+real                                             :: cf_nox(NBGMAPS)                    ! correction factors for the difference between model output and measurements for NOx
+real                                             :: cf_nh3(NBGMAPS)                    ! correction factors for the difference between model output and measurements for NH3
+real                                             :: tf_so2(NYEARS + 1)                 ! trendfactors for SO2: concentration in year T, relative to the concentration in reference year
+real                                             :: tf_no2(NYEARS + 1)                 ! trendfactors for NO2: concentration in year T, relative to the concentration in reference year
+real                                             :: tf_nh3(NYEARS + 1)                 ! trendfactors for NH3: concentration in year T, relative to the concentration in reference year
+real                                             :: nox_no2_beta(2)                    ! coefficient in conversion NO2 = beta(1)*log(NOx) + beta(2)
 CHARACTER*10                                     :: CNAME(3,5)                         ! names of substances (primary, secondary, second secondary, deposited, name in DEPAC)
 CHARACTER*10                                     :: CNAME_SUBSEC(4)                    ! names of sub-secondary species (HNO3, NO3_C, NO3_F)
 CHARACTER*10                                     :: UNITS(2)                           ! units for concentration

--- a/m_commonconst.f90
+++ b/m_commonconst.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! MODULE             : m_commonconst
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Martien de Haan (ARIS)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-F90
 ! DESCRIPTION        : Defines common parameters, values, etc.
@@ -54,7 +57,7 @@ INTEGER*4, PARAMETER                             :: NBRMAX      = 10            
 INTEGER*4, PARAMETER                             :: NCATMAX     = 199                  ! maximal number of emission categories
 INTEGER*4, PARAMETER                             :: NLANDMAX    = 50                   ! maximal number of emission countries (land << country)
 INTEGER*4, PARAMETER                             :: NBGMAPS     =  5                   ! number of background maps
-INTEGER*4, PARAMETER                             :: NYEARS      = 41                   ! number of years for interpolating backgground maps
+INTEGER*4, PARAMETER                             :: NYEARS      = 42                   ! number of years for interpolating backgground maps
 INTEGER*4, PARAMETER                             :: MAXDISTR    = 9999                 ! maximal number of distributions (for particle size or emission variation)    
 INTEGER*4, PARAMETER                             :: MAXROW      = 9999                 ! maximal number of rows in receptor grid
 INTEGER*4, PARAMETER                             :: MAXCOL      = 9999                 ! maximal number of columns in receptor grid
@@ -75,10 +78,9 @@ REAL*4                                           :: r4_for_tiny                 
 REAL*8                                           :: r8_for_tiny                        ! help variable to define DEPS_DELTA
 REAL*4,    PARAMETER                             :: EPS_DELTA   = tiny(r4_for_tiny)    ! tiny number (real)
 REAL*8,    PARAMETER                             :: DPEPS_DELTA = tiny(r8_for_tiny)    ! tiny number (double precision)
-! REAL*4,    PARAMETER                             :: PI          = 3.14159265
 REAL*4,    PARAMETER                             :: HUMAX       = 500.                 ! maximal plume height [m]      
-CHARACTER*8,  PARAMETER                          :: MODVERSIE   = '4.6.2.5'            ! model version OPS-LT
-CHARACTER*20, PARAMETER                          :: RELEASEDATE = '06 dec 2019'        ! release date
+CHARACTER*8,  PARAMETER                          :: MODVERSIE   = '5.0.0.0'            ! model version OPS-LT
+CHARACTER*20, PARAMETER                          :: RELEASEDATE = '26 dec 2019'        ! release date
 
 !
 ! CONSTANTS - Data
@@ -96,6 +98,7 @@ REAL*4                                           :: tf_no2(NYEARS + 1)          
 REAL*4                                           :: tf_nh3(NYEARS + 1)                 ! trendfactors for NH3: concentration in year T, relative to the concentration in reference year
 REAL*4                                           :: nox_no2_beta(2)                    ! coefficient in conversion NO2 = beta(1)*log(NOx) + beta(2)
 CHARACTER*10                                     :: CNAME(3,5)                         ! names of substances (primary, secondary, second secondary, deposited, name in DEPAC)
+CHARACTER*10                                     :: CNAME_SUBSEC(4)                    ! names of sub-secondary species (HNO3, NO3_C, NO3_F)
 CHARACTER*10                                     :: UNITS(2)                           ! units for concentration
 CHARACTER*10                                     :: DEPUNITS(NUNIT)                    ! units for deposition
 CHARACTER*40                                     :: KLIGEB(NKLIGEB)                    ! climate regions in NL (KLIGEB << klimaatgebieden = climate regions)
@@ -145,17 +148,17 @@ DATA cf_nh3      / 0.83, 0.83, 0.94, 1.12, 1.12 /
 DATA tf_so2      /1.11,1.39,1.79,1.27,1.19,1.20,0.94,1.00,1.04,1.02,1.10,0.62,0.65,    &  ! 1977 t/m 1989 (ref=1984)
                &                 1.60,1.70,1.46,1.33,1.00,0.86,1.02,0.78,0.63,0.50,    &  ! 1990 t/m 1999 (ref=1994)
                &            1.33,1.15,1.20,1.14,1.01,1.00,0.96,                        &  ! 2000 t/m 2006 (ref=2005)
-               &            1.72,1.85,1.75,1.44,1.14,1.00,0.98,1.10,0.81,0.61,0.58,1.00/ ! 2007 t/m 2017 plus future (ref=2012)
+               &            1.72,1.85,1.75,1.44,1.14,1.00,0.98,1.10,0.81,0.61,0.58,0.77,1.00/ ! 2007 t/m 2018 plus future (ref=2012)
 
 DATA tf_no2      /0.91,0.92,1.03,0.93,0.92,1.00,0.93,1.00,1.05,0.93,0.88,0.81,0.94,    &  ! 1977 t/m 1989 (ref=1984)
                &                 1.12,1.19,1.06,1.02,1.00,0.94,1.04,1.03,0.91,0.86,    &  ! 1990 t/m 1999 (ref=1994)
                &            1.07,1.05,1.06,1.17,1.06,1.00,0.99,                        &  ! 2000 t/m 2006 (ref=2005)
-               &            1.09,1.15,1.12,1.06,1.04,1.00,0.94,0.90,0.84,0.88,0.89,1.00/  ! 2007 t/m 2017 plus future (ref=2012)
+               &            1.09,1.15,1.12,1.06,1.04,1.00,0.94,0.90,0.84,0.88,0.89,0.88,1.00/  ! 2007 t/m 2018 plus future (ref=2012)
 
 DATA tf_nh3      /1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00,1.00,    &  ! 1977 t/m 1989 (ref=1984)
                &                 1.00,1.00,1.00,1.01,1.00,0.97,0.97,1.03,0.75,0.85,    &  ! 1990 t/m 1999 (ref=1994)
                &            0.94,1.00,0.83,1.04,0.84,1.00,1.08,                        &  ! 2000 t/m 2006 (ref=2005)
-               &            0.86,0.84,0.98,1.00,1.10,1.00,1.00,1.05,0.93,1.04,1.04,1.00/  ! 2007 t/m 2017 plus future (ref=2012)
+               &            0.86,0.84,0.98,1.00,1.10,1.00,1.00,1.05,0.93,1.04,1.04,1.51,1.00/  ! 2007 t/m 2018 plus future (ref=2012)
 !
 ! Declaration of the naming convention used for SO2, NOx and NH3
 ! CNAME(:,1): name of primary substance
@@ -169,22 +172,26 @@ DATA CNAME       /'SO2', 'NOx'     , 'NH3',  &
                &  '   ', 'NO3'     , '   ',  &
                &  'SOx', 'NOy'     , 'NHx',  &
                &  'SO2', 'NO2'     , 'NH3'   /
+               
+! CNAME_SEC is defined in ops_read_ctr               
+! DATA CNAME_SUBSEC /'HNO3', 'NO3_C', 'NO3_F' /   ! HNO3, NO3_coarse (in PM10-PM2.5), NO3_fine (in PM2.5)  
+! DATA CNAME_SUBSEC /'HNO3', 'NO3_AER' /          ! HNO3, NO3_aerosol (in PM10)
 !
 ! Units for concentration and deposition
 !
-DATA UNITS       /'ug/m3', 'ug/m3 NO2'/
+DATA UNITS       /'ug/m3', 'ug/m3_NO2'/
 DATA DEPUNITS    /' mmol/m2/s', ' g/m2/s   ', ' mol/ha/y ', ' kg/ha/y  ', ' mmol/m2/y', ' g/m2/y   '/
 
 !
 ! meteo regions (KLIGEB << klimaatgebieden = climate regions)
 !
-DATA KLIGEB      /'The Netherlands                    ',                    &
+DATA KLIGEB      /'The_Netherlands                    ',                    &
                &  'N-Holland, N-Friesland, N-Groningen',                    & 
                &  'Randstad, W-Brabant, E-Zeeland     ',                    &
                &  'Drente, S-Friesland, S-Groningen   ',                    &
                &  'W-Zeeland, ZH-Islands              ',                    &
                &  'Mid-Brabant, Veluwe, Twente        ',                    &
                &  'S-Limburg, E-Brabant, Achterhoek   ',                    &
-               &  'Special climatological datafile    '/                       ! always the last one
+               &  'Special_climatological_datafile    '/                       ! always the last one
 
 END MODULE m_commonconst

--- a/m_commonfile.f90
+++ b/m_commonfile.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! MODULE             : m_commonfile
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Martien de Haan (ARIS)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-F90
 ! DESCRIPTION        : Define file unit numbers and file names. Subroutine to make full file name.
@@ -108,10 +111,17 @@ CHARACTER*512                                    :: z0eurnam                   !
 CHARACTER*24                                     :: map_so2(5)                 ! name of file with background map SO2 (for 4 years)
 CHARACTER*24                                     :: map_nox(5)                 ! name of file with background map NOx (for 4 years)
 CHARACTER*24                                     :: map_nh3(5)                 ! name of file with background map NH3 (for 4 years)
+CHARACTER*128                                    :: map_mass_prec              ! filename with MASS_PREC averaged column mass precursor pre chemistry step, used for vchem
+CHARACTER*128                                    :: map_mass_conv_dtfac        ! filename with MASS_CONV_DTFAC = (100/dt) * averaged column mass converted in chemistry step, used for vchem
+CHARACTER*128                                    :: map_no3_distr              ! filename with distribution factors for different secondary species NO3
+                                                                               ! HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total
 
 DATA map_so2  / 'bgso2c1984.ops', 'bgso2c1994.ops', 'bgso2c2005.ops', 'bgso2c2012.ops','bgso2c2020.ops' /
 DATA map_nox  / 'bgnoxc1984.ops', 'bgnoxc1994.ops', 'bgnoxc2005.ops', 'bgnoxc2012.ops','bgnoxc2020.ops' /
 DATA map_nh3  / 'bgnh3c1984.ops', 'bgnh3c1994.ops', 'bgnh3c2005.ops', 'bgnh3c2012.ops','bgnh3c2020.ops' /
+DATA map_mass_prec       / 'xxx_mass_prec_yyyy.ops'       /   ! xxx = name primary species (SO2, NOx, NH3), yyyy = year (e.g. 2019)
+DATA map_mass_conv_dtfac / 'xxx_mass_conv_dtfac_yyyy.ops' /
+DATA map_no3_distr       / 'no3_distr_yyyy.ops' /
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE  : MakeCommonPath
 ! DESCRIPTION : Generates full file names for the common background or diurnal variation files and checks existence. An error is

--- a/m_depac.f90
+++ b/m_depac.f90
@@ -1,21 +1,24 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
+!************************************************************************
+! 2013-09-17: this version has been derived from the 'hybrid' version 
+!             depac_GCN2010, which consisted of a shell around version 
+!             depac311 (for NH3) and depac33 (for other species).
+!             In this version, only depac311 has been retained, with some 
+!             bug fixes,
 !************************************************************************
 
 !************************************************************************
@@ -27,13 +30,13 @@
 !
 !  MODULE             : m_depac
 !  INTERFACE          : depac
-!  AUTHOR             : Addo van Pul, Jan Willem Erisman, Ferd Sauter, Margreet van Zanten, Roy Wichink Kruit
+!  AUTHOR             :  
 !  FIRM/INSTITUTE     : RIVM
 !  LANGUAGE           : FORTRAN-90
 !  DESCRIPTION        : In this subroutine the canopy or surface resistance Rc
 !                       is parameterised.
 !
-! Documentation by Ferd Sauter, Mar 2009.
+! Documentation by  , Mar 2009.
 ! Deposition fluxes are computed using one of the following resistance approaches;
 ! Note that, with the appopriate definitions (see below), B and C are totally equivalent.
 !
@@ -225,10 +228,10 @@
 !  UPDATE HISTORY : 
 !    1994    , article Erisman & van Pul, Atm. Env.
 !    ?       , Franka Loeve (Cap Volmac)
-!    Jan 2003, Martien de Haan (ARIS): made single depac module.
+!    Jan 2003,  : made single depac module.
 !    ?       ,               ? (TNO) : added rc for O3
 !    ?       ,               ? (TNO) : separate routines for each species.
-!    Nov 2008, Ferd Sauter     (RIVM): v3.0 synthesis of OPS and LOTOS-EUROS versions of DEPAC
+!    Nov 2008,       (RIVM): v3.0 synthesis of OPS and LOTOS-EUROS versions of DEPAC
 !    v3.0      model structure improved; common tasks in separate routines; documentation added
 !              names have been changed for readability:
 !              
@@ -248,28 +251,28 @@
 !              gs       -> gstom        : stomatal conductance (m/s)
 !              gstot    -> gc_tot       : total canopy conductance (m/s)
 ! 
-!    10 Dec 2008, Ferd Sauter     (RIVM): v3.1 try-out version with new model structure;
+!    10 Dec 2008,       (RIVM): v3.1 try-out version with new model structure;
 !    v3.1         no calls to separate routines in subroutine depac, but all components
 !                 are dealt with in subroutine depac.
 !                 This version is NOT developed any further; depacv3.2 is developed from v3.0
 !
-!    11 Dec 2008, Ferd Sauter     (RIVM): v3.2 new model structure;
+!    11 Dec 2008,       (RIVM): v3.2 new model structure;
 !    v3.2         in subroutine depac, calls are made to routines for separate conductances, e.g.
 !                 for external, stomatal, soil conductance; the dependence on the components is 
 !                 placed inside these conductance-routines.
 !
-!    22 Jan 2009, Ferd Sauter     (RIVM): v3.3 bug fix in season dependency leaf area index;
+!    22 Jan 2009,       (RIVM): v3.3 bug fix in season dependency leaf area index;
 !    v3.3         see function rc_lai. Older versions of this routine use a wrong numbering of
 !                 land use types (no conversion to Olson land use types).  
 !                 rc_gstom_wes (Wesely) readability improved; routine gives the same results.
 !    
-!    03 Feb 2009, Ferd Sauter     (RIVM): v3.4 Rsoil(NH3,urban) = 100 (was 1000).
+!    03 Feb 2009,       (RIVM): v3.4 Rsoil(NH3,urban) = 100 (was 1000).
 !    v3.4
 !
-!    03 Feb 2009, Ferd Sauter     (RIVM): v3.5 Rinc(grass) = Inf (was 0).
+!    03 Feb 2009,       (RIVM): v3.5 Rinc(grass) = Inf (was 0).
 !    v3.5
 !
-!    03 Feb 2009, Ferd Sauter     (RIVM): v3.6 stomatal compensation point and 
+!    03 Feb 2009,       (RIVM): v3.6 stomatal compensation point and 
 !    v3.6         new parameterisation Rw.
 !                 New routines:
 !                     rc_comp_point (called from depac)
@@ -278,7 +281,7 @@
 !                 New option ipar_rw_nh3.    (obsolete in final version MCvZ Nov 2009)
 !                 New (optional) arguments of depac: see header of depac.
 !
-!    02 Mar 2009, Ferd Sauter     (RIVM): v3.7 
+!    02 Mar 2009,       (RIVM): v3.7 
 !    v3.7         - added compensation point for external leaf; 
 !                   new parameterisation for Rw (routine rw_nh3_sutton replaces rw_nh3_rwk);
 !                 - added compensation point for soil; value of compensation point
@@ -288,17 +291,17 @@
 !                   parameterisation of Rstom; it was decided to change not everything in this version
 !                   but to do it stepwise. See v3.8 for Baldocchi
 !
-!    10 Mar 2009, Ferd Sauter     (RIVM): v3.8
+!    10 Mar 2009,       (RIVM): v3.8
 !    v3.8         - the same as v3.7, but Baldocchi for Rstom
 !    
-!    24 Mar 2009, Ferd Sauter     (RIVM): v3.8.1 LAI in external leaf resistance
+!    24 Mar 2009,       (RIVM): v3.8.1 LAI in external leaf resistance
 !    v3.8.1       gw = (lai/lai(grass)) * gw   (adjusted Oct 2009; lai -> sai and 
 !                 sai_grass scaling inside rw_nh3_sutton routine)
 !
-!    9 Apr 2009, Ferd Sauter     (RIVM): v3.8.2 bug fix in temperature
+!    9 Apr 2009,       (RIVM): v3.8.2 bug fix in temperature
 !    v3.8.2      correction factor Baldocchi BT 
 !
-!    6 July 2009, Ferd Sauter    (RIVM): v3.9 call added to calculate Rstom with Emberson
+!    6 July 2009,      (RIVM): v3.9 call added to calculate Rstom with Emberson
 !    v3.9
 !
 !    13 Aug 2009, Margreet van Zanten (RIVM): Emberson update, PARshade and PARsun added 
@@ -310,13 +313,13 @@
 !    9  Sep 2009, Margreet van Zanten (RIVM): calc of PARdir and PARdiff in Emberson
 !                 according to Weiss and Norman 1985
 !
-!    22 Sep 2009, Ferd Sauter (RIVM): gstom of Emberson scaled with diffc/dO3 (instead of
+!    22 Sep 2009,   (RIVM): gstom of Emberson scaled with diffc/dO3 (instead of
 !    v3.10        erroneously with dwat)
 !
 !    24 Sep 2009, Margreet van Zanten (RIVM): choices made on lu classes, F_phen set to 1 
 !                  since described effect is negligible for chosen lu's
 !    
-!    29 Sep 2009, Ferd Sauter (RIVM): Emberson parameterisation of leaf area index (rc_lai);
+!    29 Sep 2009,   (RIVM): Emberson parameterisation of leaf area index (rc_lai);
 !                  new subroutine arguments for DEPAC: day_of_year and lat (latitude).
 !
 !    2 Oct  2009, Margreet van Zanten (RIVM): v3.10 Merged version of earlier version of 3.10 and 3.9.2 
@@ -363,14 +366,14 @@
 !                calling depac routine for several components in a row (esp. NO after NH3), 
 !                ccomp_tot added as optional argument to rc_special routine
 !
-!   04 Jan 2010, Ferd Sauter (RIVM): v3.16 is shell around versions 3.11 ('new' DEPAC for NH3 only) 
+!   04 Jan 2010,   (RIVM): v3.16 is shell around versions 3.11 ('new' DEPAC for NH3 only) 
 !   v3.16        and 3.3 (old DEPAC for other species).       
 !                This file is constructed as follows:
 !                module m_depac311
 !                module m_depac33
 !                module m_depac316
 !
-!   04 Jan 2010, Ferd Sauter (RIVM): iopt_debug -> optional writing of debug output
+!   04 Jan 2010,   (RIVM): iopt_debug -> optional writing of debug output
 !   v3.16        added to m_depac311 and m_depac33 in this file 
 !
 !   04 Jan 2010, Margreet van Zanten(RIVM): frozen version of depac v3.16, renamed in depac_GCN2010
@@ -450,7 +453,7 @@ END SUBROUTINE get_version_depac
 ! depac: compute total canopy (or surface) resistance Rc for gases
 !-------------------------------------------------------------------
 subroutine depac318(compnam, day_of_year, lat, t, ust, glrad, sinphi, rh, nwet, lu, iratns, rc_tot, &
-                   c_ave_prev, catm, ccomp_tot, &
+                   c_ave_prev_nh3, c_ave_prev_so2, catm, ccomp_tot, &
                    ra, rb, rc_eff)
 
 !DEC$ ATTRIBUTES DLLEXPORT:: depac318
@@ -462,11 +465,11 @@ subroutine depac318(compnam, day_of_year, lat, t, ust, glrad, sinphi, rh, nwet, 
 !
 ! B. compute Rc (incl. new parameterisation Rw) and compensation points (used for LOTOS-EUROS): 
 !     call depac (compnam, day_of_year, lat, t, ust, glrad, sinphi, rh, nwet, lu, iratns, rc_tot, &
-!                  c_ave_prev, catm, ccomp_tot)
+!                  c_ave_prev_nh3, c_ave_prev_so2, catm, ccomp_tot)
 !
 ! C. compute effective Rc based on compensation points, incl. new parameterisation Rw (used for OPS):
 !     call depac (compnam, day_of_year, lat, t, ust, glrad, sinphi, rh, nwet, lu, iratns, rc_tot, &
-!                 c_ave_prev, catm, ccomp_tot, &
+!                 c_ave_prev_nh3, c_ave_prev_so2, catm, ccomp_tot, &
 !                 ra, rb, rc_eff)
 
 implicit none
@@ -490,8 +493,10 @@ integer         , intent(in)  :: iratns       ! index for NH3/SO2 ratio;
 real            , intent(out) :: rc_tot       ! total canopy resistance Rc (s/m)
 
 ! optional arguments needed only if compensation points are computed
-real, optional  , intent(in)  :: c_ave_prev   ! air concentration averaged over a previous
-                                              ! period (e.g. previous year or month) (ug/m3) 
+real, optional  , intent(in)  :: c_ave_prev_nh3   ! air concentration averaged over a previous
+                                                  ! period (e.g. previous year or month) (ug/m3) 
+real, optional   , intent(in) :: c_ave_prev_so2   ! air concentration averaged over a previous
+                                                  ! period (e.g. previous year or month) (ug/m3)
 real, optional  , intent(in)  :: catm         ! actual atmospheric concentration (ug/m3)
 real, optional  , intent(out) :: ccomp_tot    ! total compensation point (ug/m3)
 
@@ -546,8 +551,8 @@ if (.not. ready) then
    call rc_rctot(gstom,gsoil_eff,gw,gc_tot,rc_tot)
    
    ! Compensation points:
-   if (present(c_ave_prev) .and. present(catm) .and. present(ccomp_tot)) then
-      call rc_comp_point(compnam,lu,day_of_year,t,catm,c_ave_prev,gw,gstom,gsoil_eff,gc_tot,ccomp_tot)
+   if (present(c_ave_prev_nh3) .and. present(c_ave_prev_so2) .and. present(catm) .and. present(ccomp_tot)) then
+      call rc_comp_point(compnam,lu,day_of_year,t,catm,c_ave_prev_nh3,c_ave_prev_so2,gw,gstom,gsoil_eff,gc_tot,ccomp_tot)
 
       ! Effective Rc based on compensation points:
       if (present(rc_eff)) then
@@ -1503,7 +1508,7 @@ end subroutine rc_rctot
 !-------------------------------------------------------------------
 ! rc_comp_point: calculate compensation points (stomata, external leaf)
 !-------------------------------------------------------------------
-subroutine rc_comp_point(compnam,lu,day_of_year,t,catm,c_ave_prev,gw,gstom,gsoil_eff,gc_tot,ccomp_tot)
+subroutine rc_comp_point(compnam,lu,day_of_year,t,catm,c_ave_prev_nh3,c_ave_prev_so2,gw,gstom,gsoil_eff,gc_tot,ccomp_tot)
 
 ! Calculate ccomp, i.e. compensation point for NH3, for different deposition path ways
 ! (external leaf, stomata, soil), according to Roy Wichink Kruit article submitted 2009 Atm. Env.
@@ -1518,7 +1523,7 @@ subroutine rc_comp_point(compnam,lu,day_of_year,t,catm,c_ave_prev,gw,gstom,gsoil
 ! The [NH4+]/[H+] ratio gamma depends on 
 ! 1. for stomata
 !    the average concentration over a previous period:
-!    gamma_stom = gamma_stom_c_fac * c_ave_prev
+!    gamma_stom = gamma_stom_c_fac * c_ave_prev_nh3
 !
 ! 2. for external leaf
 !    actual atmospheric concentration at 4 m. and surface temperature:
@@ -1538,8 +1543,11 @@ integer, intent(in)           :: lu           ! land use type, lu = 1,...,9
 integer, intent (in)          :: day_of_year  ! day of year 
 real, intent(in)              :: t            ! temperature (C) 
 real, intent(in)              :: catm         ! actual atmospheric concentration (ug/m3)
-real, intent(in)              :: c_ave_prev   ! air concentration averaged over a previous
-                                              ! period (e.g. previous year or month) (ug/m3) 
+real, intent(in)              :: c_ave_prev_nh3   ! air concentration averaged over a previous
+                                                  ! period (e.g. previous year or month) (ug/m3) 
+!real, optional,  intent(in)   :: c_ave_prev_so2   ! air concentration averaged over a previous
+real, intent(in)   :: c_ave_prev_so2   ! air concentration averaged over a previous
+                                                  ! period (e.g. previous year or month) (ug/m3)
 real, intent(in)              :: gw           ! external leaf conductance (m/s) 
 real, intent(in)              :: gstom        ! stomatal conductance (m/s)
 real, intent(in)              :: gsoil_eff    ! effective soil conductance (m/s)
@@ -1560,6 +1568,7 @@ real :: gamma_soil ! [NH4+]/[H+] ratio in soil
 real :: gamma_w    ! [NH4+]/[H+] ratio in external leaf surface water
 real :: tk         ! temperature (K) 
 real :: tfac       ! temperature factor = (2.75e15/tk)*exp(-1.04e4/tk)
+real :: co_dep_fac ! co-deposition factor 
 
 real   , dimension(nlu)    :: gamma_stom_c_fac   ! factor in linear relation between gamma_stom and NH3
                                                  ! air concentration; gamma_stom = [NH4+]/[H+] ratio in apoplast
@@ -1595,10 +1604,10 @@ case('NH3')
    tfac = (2.75e15/tk)*exp(-1.04e4/tk)
    
    ! Stomatal compensation point:
-   if (LAI_present .and. c_ave_prev .gt. 0.) then
+   if (LAI_present .and. c_ave_prev_nh3 .gt. 0.) then
       ! gamma_stom ([NH4+]/[H+] ratio in apoplast) is linearly dependent on an 
       ! averaged air concentration in a previous period (stored in soil and leaves):
-       gamma_stom = gamma_stom_c_fac(lu)*c_ave_prev*4.7*exp(-0.071*t)
+       gamma_stom = gamma_stom_c_fac(lu)*c_ave_prev_nh3*4.7*exp(-0.071*t)
    
       ! calculate stomatal compensation point for NH3 in ug/m3:
       cstom = max(0.0,gamma_stom*tfac)
@@ -1609,15 +1618,29 @@ case('NH3')
    
    ! External leaf gamma depends on atmospheric concentration and
    ! surface temperature (assumed to hold for all land use types with vegetation):
-   if (SAI_present) then
+!   if (SAI_present .and. present(catm) .and. present(c_ave_prev_nh3) .and. present(c_ave_prev_so2) .and. c_ave_prev_nh3 .gt. 0. .and. c_ave_prev_so2 .gt. 0.) then
+   if (SAI_present .and. c_ave_prev_nh3 .gt. 0. .and. c_ave_prev_so2 .gt. 0.) then
+      gamma_w = -850.+1840.*catm*exp(-0.11*t)
+      ! correction gamma_w for co deposition 
+      ! xxx documentation to be added
+      ! gamma(with SNratio) = [1.12-1.32*SNratio(molair)]  * gamma_original   
+      ! where SNratio(molar) = (CSO2longterm/64)/(CNH3longterm/17))
+      !   where CSO2longterm and CNH3longterm in ug m-3.
+      co_dep_fac = 1.12 - 1.32 * ((c_ave_prev_so2/64.)/(c_ave_prev_nh3/17.))
+      co_dep_fac = max(0.0,co_dep_fac)   
+      gamma_w = co_dep_fac * gamma_w 
+      cw      = max(0.0,gamma_w*tfac)
+!   elseif (SAI_present .and. present(catm)) then
+   elseif (SAI_present) then
       gamma_w = -850.+1840.*catm*exp(-0.11*t)
       cw      = max(0.0,gamma_w*tfac)
    else
       cw = 0.0
    endif
-   
+
+
    ! Soil compensation point:
-   if (c_ave_prev .gt. 0. .and. gamma_soil_c_fac(lu) > 0) then
+   if (c_ave_prev_nh3 .gt. 0. .and. gamma_soil_c_fac(lu) > 0) then
         if (lu .eq. 6)then
           ! gamma_soil for water is determined to be 430 based on Waterbase data, 
           ! here it is 'calculated' analogous to the other gamma_stom 
@@ -1625,7 +1648,7 @@ case('NH3')
         else
           ! gamma_soil ([NH4+]/[H+] ratio in soil) is linearly dependent on an 
           ! averaged air concentration in a previous period:
-          gamma_soil = gamma_soil_c_fac(lu)*c_ave_prev
+          gamma_soil = gamma_soil_c_fac(lu)*c_ave_prev_nh3
         endif
       ! calculate soil compensation point for NH3 in ug/m3:
       csoil = gamma_soil*tfac
@@ -1653,7 +1676,7 @@ end subroutine rc_comp_point
 ! old name: NH3rc (see depac v3.6 is based on Avero workshop Marc Sutton. p. 173. 
 ! Sutton 1998 AE 473-480)
 !
-! Documentation by Ferd Sauter, 2008; see also documentation block in header of this module.
+! Documentation by  , 2008; see also documentation block in header of this module.
 
 
 !

--- a/m_error.f90
+++ b/m_error.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! MODULE             : m_error
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Martien de Haan (ARIS)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-F90
 ! DESCRIPTION        : Handling of errors occurring in ops.

--- a/m_error.f90
+++ b/m_error.f90
@@ -372,7 +372,7 @@ SUBROUTINE error_rparam(paramname, value, error)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: paramname                  ! 
-REAL*4,    INTENT(IN)                            :: value                      ! 
+real,      INTENT(IN)                            :: value
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! 
@@ -398,7 +398,7 @@ SUBROUTINE error_raparam(paramname, value, error)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: paramname                  ! 
-REAL*4,    INTENT(IN)                            :: value(:)                   ! 
+real,      INTENT(IN)                            :: value(:)
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! 

--- a/m_error.f90
+++ b/m_error.f90
@@ -59,7 +59,7 @@ TYPE TErrorParam
    CHARACTER                                     :: paramtype                  ! type of parameter
    CHARACTER*512                                 :: stringvalue                ! string value
    INTEGER*4                                     :: intvalue                   ! integer value
-   REAL*4                                        :: realvalue                  ! real value
+   real                                          :: realvalue                  ! real value
    TYPE (TErrorParam), pointer                   :: nextparam                  ! pointer to next parameter
 END TYPE TErrorParam
 
@@ -119,8 +119,8 @@ INTERFACE ErrorParam
    MODULE PROCEDURE error_iparam                                               ! integer*4 parameter
    MODULE PROCEDURE error_iaparam                                              ! integer*4 parameter array
    MODULE PROCEDURE error_lparam                                               ! logical parameter
-   MODULE PROCEDURE error_rparam                                               ! real*4 parameter
-   MODULE PROCEDURE error_raparam                                              ! real*4 parameter array
+   MODULE PROCEDURE error_rparam                                               ! real parameter
+   MODULE PROCEDURE error_raparam                                              ! real parameter array
    MODULE PROCEDURE error_sparam                                               ! character*(*) string parameter
    MODULE PROCEDURE error_wparam                                               ! character*(*) string parameter, but only first word is written
    MODULE PROCEDURE error_saparam                                              ! character*(*) string parameter array
@@ -995,7 +995,7 @@ SUBROUTINE simple_r_append(realvalue, significance, targetstring)
 !DEC$ ATTRIBUTES DLLEXPORT:: simple_r_append
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: realvalue                  ! string to be appended
+real,      INTENT(IN)                            :: realvalue                  ! string to be appended
 INTEGER*4, INTENT(IN)                            :: significance               ! number of significant digits
 
 ! SUBROUTINE ARGUMENTS - I/O
@@ -1018,8 +1018,8 @@ SUBROUTINE simple_rb_append(nrblanks, realvalue, significance, targetstring)
 USE m_commonconst                                                              ! EPS_DELTA only
 
 ! SUBROUTINE ARGUMENTS - INPUT
-INTEGER*4, INTENT(IN)                            :: nrblanks                   ! 
-REAL*4,    INTENT(IN)                            :: realvalue                  ! string to be appended
+INTEGER*4, INTENT(IN)                            :: nrblanks
+real,      INTENT(IN)                            :: realvalue                  ! string to be appended
 INTEGER*4, INTENT(IN)                            :: significance               ! number of significant digits
 
 ! SUBROUTINE ARGUMENTS - I/O
@@ -1030,7 +1030,7 @@ INTEGER*4                                        :: targetlength               !
 INTEGER*4                                        :: position                   ! position counter in writing to string
 INTEGER*4                                        :: power                      ! the e-value in the number
 INTEGER*4                                        :: counter                    ! simple loop counter
-REAL*4                                           :: realcopy                   ! copy of realvalue
+real                                             :: realcopy                   ! copy of realvalue
 INTEGER*4                                        :: intcopy                    ! copy of significant realvalue
 INTEGER*4                                        :: intcopy2                   ! copy of significant realvalue
 INTEGER*4                                        :: char0                      ! '0' character

--- a/m_fileutils.f90
+++ b/m_fileutils.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! MODULE               : fileutils
 ! NAME                 : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE     : %B% - %S%
 ! DATE - TIME          : %E% - %U%
 ! WHAT                 : %W%:%E%
-! AUTHOR               :
+! AUTHOR               : OPS-support 
 ! FIRM/INSTITUTE       : RIVM/LLO/IS
 ! LANGUAGE             : FORTRAN-90
 ! DESCRIPTION          : This module contains all utilities handling files.
@@ -76,7 +79,7 @@ END INTERFACE
 ! PURPOSE     : Checking the existence of a file. If the file does not exist the error message is assigned. The callback of the
 !               error is not assigned, so that it appears the non-existing error is detected in the calling procedure (which is
 !               what the user wants to know).
-! AUTHOR      : Martien de Haan (ARIS).
+! AUTHOR      : OPS-support   .
 ! INPUTS      : fname  (character*(*)). The full path of the file.
 ! OUTPUTS     : error  (type TError). Is assigned when the file does not exist.
 ! RESULT      : .TRUE. when the file exists, .FALSE. if not.
@@ -88,7 +91,7 @@ END INTERFACE
 !-------------------------------------------------------------------------------------------------------------------------------
 ! FUNCTION    : sysopen
 ! PURPOSE     : Opens a file for reading or writing.
-! AUTHOR      : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR      : OPS-support   
 ! INPUTS      : iu     (integer*4). Unit number of file.
 !               filename (character*(*)). Path of file to be opened.
 !               rw     (character*(*)). Whether reading or writing. Options:
@@ -109,7 +112,7 @@ END INTERFACE
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE  : sysclose
 ! PURPOSE     : Closes a file. Low level.
-! AUTHOR      : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR      : OPS-support   
 ! ADAPTATIONS : 2002 - Error handling through error object (Martien de Haan, ARIS).
 ! INPUTS      : iu     (integer*4). Unit number of file.
 !               filename (character*(*)). Name of file. Only relevant when error is written.
@@ -123,7 +126,7 @@ END INTERFACE
 ! SUBROUTINE  : sysread
 ! PURPOSE     : Reads a string from an input device.
 ! PRECONDITION: Input file: Ascii, recordlength <= 512
-! AUTHOR      : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR      : OPS-support   
 ! ADAPTATIONS : 2002 - Error handling through error object (Martien de Haan, ARIS).
 ! INPUTS      : iu     (integer*4). Unit number of file.
 ! OUTPUTS     : end_of_file (logical) Whether end-of-file was reached, so that nothing was read.
@@ -467,7 +470,7 @@ END SUBROUTINE sys_close_file
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE: sysopen_read
 ! PURPOSE   : Opening of text file for reading. See interface definition
-! AUTHOR    : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR    : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE sysopen_read(iu, fnam, io_status)
 
@@ -499,7 +502,7 @@ END SUBROUTINE sysopen_read
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE: sysopen_read_bin
 ! PURPOSE   : Opening of binary file for reading.
-! AUTHOR    : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR    : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE sysopen_read_bin(iu, fnam, io_status)
 
@@ -528,7 +531,7 @@ END SUBROUTINE sysopen_read_bin
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE: sysopen_write
 ! PURPOSE   : Opening of text file for writing.
-! AUTHOR    : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR    : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE sysopen_write(iu, fnam, io_status)
 
@@ -564,7 +567,7 @@ END SUBROUTINE sysopen_write
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE: sysopen_direct
 ! PURPOSE   : Opening of direct-access file for reading.
-! AUTHOR    : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR    : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE sysopen_direct(iu, fnam, LREC, io_status)
 
@@ -601,7 +604,7 @@ END SUBROUTINE sysopen_direct
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE: sysread
 ! PURPOSE   : Reading a string from a file
-! AUTHOR    : Erik Bobeldijk/Franka Loeve (Cap Volmac)
+! AUTHOR    : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE sys_read_string(fdin, in_str, end_of_file, error)
 

--- a/m_geoutils.f90
+++ b/m_geoutils.f90
@@ -64,10 +64,10 @@ IMPLICIT NONE
 !                       ca. 10000 km west (y < 4000 km)  -96 lon 17 lat
 !                       ca.  6000 km west (y < 5000 km)  -95 lon 47 lat
 !
-! INPUTS      : amcx     (real*4), RDM x-coordinate [km]
-!               amcy     (real*4), RDM y-coordinate [km]
-! OUTPUTS     : geol     (real*4), longitude [degrees]
-!               geob     (real*4), latitude  [degrees]
+! INPUTS      : amcx     (real), RDM x-coordinate [km]
+!               amcy     (real), RDM y-coordinate [km]
+! OUTPUTS     : geol     (real), longitude [degrees]
+!               geob     (real), latitude  [degrees]
 !               "geo" << geographical coordinates; "l" << lengtegraad = longitude, "b" << breedtegraad = latitude
 !-------------------------------------------------------------------------------------------------------------------------------
 
@@ -78,10 +78,10 @@ END INTERFACE
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE  : geo2amc
 ! PURPOSE     : Convert greographical lon-lat coordinates to RDM coordinates
-! INPUTS      : geob    (real*4), latitude, phi (degrees)
-!               geob    (real*4), longitude, lambda (degrees)
-! OUTPUTS     : amcx    (real*4), RDM x-coordinate
-!               amcx    (real*4), RDM y-coordinate
+! INPUTS      : geob    (real), latitude, phi (degrees)
+!               geob    (real), longitude, lambda (degrees)
+! OUTPUTS     : amcx    (real), RDM x-coordinate
+!               amcx    (real), RDM y-coordinate
 !-------------------------------------------------------------------------------------------------------------------------------
 
 INTERFACE geo2amc
@@ -91,10 +91,10 @@ END INTERFACE
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE  : amc2lam
 ! PURPOSE     : Berekenen van de lambert azimuthal equal area coordinaten (x,y) in km. uit de topografische (amersfoortse) coordinaten.
-! INPUTS      : amcx   (real*4), x-coordinaat, Amersfoorts
-!               amcy   (real*4), y-coordinaat, Amersfoorts
-! OUTPUTS     : lamx   (real*4), x-coordinaat, Lambert azimuthaal
-!             : lamy   (real*4), y-coordinaat, Lambert azimuthaal
+! INPUTS      : amcx   (real), x-coordinaat, Amersfoorts
+!               amcy   (real), y-coordinaat, Amersfoorts
+! OUTPUTS     : lamx   (real), x-coordinaat, Lambert azimuthaal
+!             : lamy   (real), y-coordinaat, Lambert azimuthaal
 !-------------------------------------------------------------------------------------------------------------------------------
 
 INTERFACE amc2lam
@@ -104,10 +104,10 @@ END INTERFACE
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE  : geo2lam
 ! PURPOSE     : Berekenen van de lambert azimuthal equal area coordinaten (x,y) in km. uit de geografische coordinaten.
-! INPUTS      : geob   (real*4), breedtegraad, phi (dec.)
-!               geol   (real*4), lengtegraad, labda (dec.)
-! OUTPUTS     : lamx   (real*4), x-coordinaat, Lambert azimuthaal
-!             : lamy   (real*4), y-coordinaat, Lambert azimuthaal
+! INPUTS      : geob   (real), breedtegraad, phi (dec.)
+!               geol   (real), lengtegraad, labda (dec.)
+! OUTPUTS     : lamx   (real), x-coordinaat, Lambert azimuthaal
+!             : lamy   (real), y-coordinaat, Lambert azimuthaal
 !-------------------------------------------------------------------------------------------------------------------------------
 
 INTERFACE geo2lam
@@ -131,21 +131,21 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'amc2geo')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: amcx                       ! RDM x-coordinate (km)
-REAL*4,    INTENT(IN)                            :: amcy                       ! RDM y-coordinate (km)
+real,      INTENT(IN)                            :: amcx                       ! RDM x-coordinate (km)
+real,      INTENT(IN)                            :: amcy                       ! RDM y-coordinate (km)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: geol                       ! longitude [degrees]
-REAL*4,    INTENT(OUT)                           :: geob                       ! latitude  [degrees]
+real,      INTENT(OUT)                           :: geol                       ! longitude [degrees]
+real,      INTENT(OUT)                           :: geob                       ! latitude  [degrees]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: tel                        ! iteration index
-REAL*4                                           :: difx                       ! threshold value for dx
-REAL*4                                           :: dify                       ! threshold value for dy
-REAL*4                                           :: dx                         ! x - x0
-REAL*4                                           :: dy                         ! y - y0
-REAL*4                                           :: amcx0                      ! RDM x-coordinate that corresponds with (gb,gl)
-REAL*4                                           :: amcy0                      ! RDM y-coordinate that corresponds with (gb,gl)
+real                                             :: difx                       ! threshold value for dx
+real                                             :: dify                       ! threshold value for dy
+real                                             :: dx                         ! x - x0
+real                                             :: dy                         ! y - y0
+real                                             :: amcx0                      ! RDM x-coordinate that corresponds with (gb,gl)
+real                                             :: amcy0                      ! RDM y-coordinate that corresponds with (gb,gl)
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -228,24 +228,24 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'geo2amc')
 
 ! CONSTANTS
-REAL*4                                           :: AMFI                       ! longitude (phi) of Amersfoort (centre of RDM grid)
-REAL*4                                           :: AMLA                       ! latitude (lambda) of Amersfoort (centre of RDM grid)
+real                                             :: AMFI                       ! longitude (phi) of Amersfoort (centre of RDM grid)
+real                                             :: AMLA                       ! latitude (lambda) of Amersfoort (centre of RDM grid)
 PARAMETER (AMFI = 18.7762) 
 PARAMETER (AMLA =  1.9395) 
 ! 1 degree = 3600 seconds; AMFI, AMLA in units of 10000 seconds; conversion factor to degrees = 10000/3600:
 ! 10000*[AMFI, AMLA]/3600 = [AMFI, AMLA]/0.36 = [18.7762 1.9395]/0.36 = [52.1561 5.3875] = [Lat, Lon]_Amersfoort
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: geol                       ! longitude (phi)   [degrees]
-REAL*4,    INTENT(IN)                            :: geob                       ! latitude (lambda) [degrees]
+real,      INTENT(IN)                            :: geol                       ! longitude (phi)   [degrees]
+real,      INTENT(IN)                            :: geob                       ! latitude (lambda) [degrees]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: amcx                       ! RDM x-coordinate (km)
-REAL*4,    INTENT(OUT)                           :: amcy                       ! RDM y-coordinate (km
+real,      INTENT(OUT)                           :: amcx                       ! RDM x-coordinate (km)
+real,      INTENT(OUT)                           :: amcy                       ! RDM y-coordinate (km
 
 ! LOCAL VARIABLES
-REAL*4                                           :: f1                         ! 
-REAL*4                                           :: l1                         ! 
+real                                             :: f1
+real                                             :: l1
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -278,16 +278,16 @@ PARAMETER    (ROUTINENAAM = 'amc2lam')
 ! CONSTANTS
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: amcx                       ! amersfoortse x-coordinaat (km)
-REAL*4,    INTENT(IN)                            :: amcy                       ! amersfoortse y-coordinaat (km)
+real,      INTENT(IN)                            :: amcx                       ! amersfoortse x-coordinaat (km)
+real,      INTENT(IN)                            :: amcy                       ! amersfoortse y-coordinaat (km)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: lamx                       ! lambert azimuthal x-coordinaat (km)
-REAL*4,    INTENT(OUT)                           :: lamy                       ! lambert azimuthal y-coordinaat (km)
+real,      INTENT(OUT)                           :: lamx                       ! lambert azimuthal x-coordinaat (km)
+real,      INTENT(OUT)                           :: lamy                       ! lambert azimuthal y-coordinaat (km)
 
 ! LOCAL VARIABLES
-REAL*4                                           :: geol                       ! hulpvariabele voor phi
-REAL*4                                           :: geob                       ! hulpvariabele voor lambda
+real                                             :: geol                       ! hulpvariabele voor phi
+real                                             :: geob                       ! hulpvariabele voor lambda
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -321,12 +321,12 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'geo2lam')
 
 ! CONSTANTS
-REAL*8                                           :: false_east                 ! linear value added to the x-coordinate values (longitude)
-REAL*8                                           :: false_north                ! linear value added to the y-coordinate values (latitude)
-REAL*8                                           :: R                          ! radius of the earth (equatorial)
-REAL*8                                           :: degtorad                   ! degrees to radians
-REAL*8                                           :: cen_med                    ! central median or central longitude
-REAL*8                                           :: lat_ori                    ! latitude of origen or standard parallel
+double precision                                 :: false_east                 ! linear value added to the x-coordinate values (longitude)
+double precision                                 :: false_north                ! linear value added to the y-coordinate values (latitude)
+double precision                                 :: R                          ! radius of the earth (equatorial)
+double precision                                 :: degtorad                   ! degrees to radians
+double precision                                 :: cen_med                    ! central median or central longitude
+double precision                                 :: lat_ori                    ! latitude of origen or standard parallel
 
 PARAMETER (false_east  = 4321000)
 PARAMETER (false_north = 3210000)
@@ -336,27 +336,27 @@ PARAMETER (cen_med     = 10)
 PARAMETER (lat_ori     = 52)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: geob                         ! breedtegraad (lambda)     (dec.) (lat)
-REAL*4,    INTENT(IN)                            :: geol                         ! lengtegraad (phi)         (dec.) (lon)
+real,      INTENT(IN)                            :: geob                         ! breedtegraad (lambda)     (dec.) (lat)
+real,      INTENT(IN)                            :: geol                         ! lengtegraad (phi)         (dec.) (lon)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: lamx                         ! lambert azimuthal x-coordinaat (km)
-REAL*4,    INTENT(OUT)                           :: lamy                         ! lambert azimuthal y-coordinaat (km)
+real,      INTENT(OUT)                           :: lamx                         ! lambert azimuthal x-coordinaat (km)
+real,      INTENT(OUT)                           :: lamy                         ! lambert azimuthal y-coordinaat (km)
 
 ! LOCAL VARIABLES
-real*8                                           :: ksp
-real*8                                           :: lon                          ! longitude of the original grid
-real*8                                           :: lat                          ! latitude of the original grid
-real*8                                           :: sin_lat
-real*8                                           :: cos_lat
-real*8                                           :: sin_lon
-real*8                                           :: cos_lon
-real*8                                           :: sin_lat_ori
-real*8                                           :: cos_lat_ori
-real*8                                           :: sin_lon_delta
-real*8                                           :: cos_lon_delta
-real*8                                           :: x
-real*8                                           :: y
+double precision                                 :: ksp
+double precision                                 :: lon                          ! longitude of the original grid
+double precision                                 :: lat                          ! latitude of the original grid
+double precision                                 :: sin_lat
+double precision                                 :: cos_lat
+double precision                                 :: sin_lon
+double precision                                 :: cos_lon
+double precision                                 :: sin_lat_ori
+double precision                                 :: cos_lat_ori
+double precision                                 :: sin_lon_delta
+double precision                                 :: cos_lon_delta
+double precision                                 :: x
+double precision                                 :: y
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/m_geoutils.f90
+++ b/m_geoutils.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! MODULE             : geoutils
 ! IMPLEMENTS         : - amc2geo: conversion of RDM to geographical lon-lat coordinates
@@ -26,7 +29,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM LLO
 ! LANGUAGE           : FORTRAN-90
 ! DESCRIPTION        : This module contains geographical utilities.

--- a/m_getkey.f90
+++ b/m_getkey.f90
@@ -62,7 +62,7 @@ IMPLICIT NONE
 ! REMARK      : GetKeyValue is generic for the following types:
 !                           strings (character*(*))
 !                           integer*4
-!                           real*4
+!                           real
 !                           logical
 !-------------------------------------------------------------------------------------------------------------------------------
 INTERFACE GetKeyValue
@@ -86,7 +86,7 @@ END INTERFACE
 ! RESULT      : Logical.    False if an error was detected.
 ! REMARK      : GetCheckedKey is generic for the following types:
 !                           integer*4
-!                           real*4
+!                           real
 ! REMARK2     : A special checked key instance checks filepaths and has a different profile (isrequired is not passed):
 !             : parname    (character*(*)). Name of the parameter. checkdefine(logical). If flag is set: test whether name was
 !                           entered.
@@ -529,12 +529,12 @@ FUNCTION check_range_real(parname,lower,upper,isrequired, value, error)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: parname                    ! 
-REAL*4,    INTENT(IN)                            :: lower                      ! lower limit of value
-REAL*4,    INTENT(IN)                            :: upper                      ! upper limit of value
+real,      INTENT(IN)                            :: lower                      ! lower limit of value
+real,      INTENT(IN)                            :: upper                      ! upper limit of value
 LOGICAL,   INTENT(IN)                            :: isrequired                 ! whether a value is required
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: value                      ! real value extracted
+real,      INTENT(OUT)                           :: value                      ! real value extracted
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! RESULT

--- a/m_getkey.f90
+++ b/m_getkey.f90
@@ -230,7 +230,7 @@ FUNCTION get_key_real(parname, value, error)
 CHARACTER*(*), INTENT(IN)                        :: parname                    ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: value                      ! 
+real,      INTENT(OUT)                           :: value
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
 
 ! RESULT

--- a/m_ops_building.f90
+++ b/m_ops_building.f90
@@ -1,22 +1,18 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
-!-------------------------------------------------------------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 module m_ops_building
 
 implicit none
@@ -26,11 +22,11 @@ implicit none
 !  General setup up of multi dimensional lookup table
 !
 !  1) Class definition file:
-!  A file with n parameters at n rows; each row contains a parameter with a generic names of the parameter in the first column,
+!  A file with n parameters at n rows; each row contains a parameter with a generic names of the parameter in the first column, 
 !  followed by a number of columns with representative parameter values for each class. Note that each parameter can have a different number of classes.
 !  Example file:
 !  p1  5.0  9.0  16.0  25  50   75   100
-!  p2  5.0  9.0  20.0
+!  p2  5.0  9.0  20.0 
 !  **
 !  pn  10  20  30  40  50  60
 !
@@ -38,11 +34,11 @@ implicit none
 !
 !  2) Lookup table:
 !  Table with n + 1 columns containing the class indices for n parameters and the associated building effect factor.
-!  Example lookup table
+!  Example lookup table 
 !  1. last parameter varies first, then last but one, ... THIS IS ESSENTIAL FOR CORRECT READING OF THE DATA!
 !  2. !  Last two parameters must be (source-receptor angle, source-receptor distance
 !    p1     p2   ***    pn  buildingFact
-!     1      1           1          2.20
+!     1      1           1          2.20  
 !     1      1           2          2.10
 !     1      1           3          1.90
 !     1      1           4          1.85
@@ -51,7 +47,7 @@ implicit none
 !     1      2           1          2.30
 !     1      2           2          2.15
 !     .......
-!     3      2           5          1.26
+!     3      2           5          1.26 
 !     3      2           6          1.05
 !
 !  Note that class i of a parameter corresponds to column i+1 for this parameter in the class definition file.
@@ -65,7 +61,7 @@ integer, parameter         :: mParam = 9                       ! maximal number 
 integer, parameter         :: mClass = 100                     ! maximal number of classes for any parameter
 
 ! Define parameter names - these must be the same as the parameters as filled into valueArray (see ops_bron_rek) - distance must be last parameter !
-!character(len=200)         :: buildingParamNames(3) = (/'hEmis', 'angleSRxaxis', 'distance' /)  ! 3 parameters, simple test
+!character(len=200)         :: buildingParamNames(3) = (/'hEmis', 'angleSRxaxis', 'distance' /)  ! 3 parameters, simple test 
 character(len=200)         :: buildingParamNames(9) = (/'hEmis', 'V_stack', 'D_stack', 'buildingHeight', 'buildingLength', 'buildingWLRatio', 'buildingOrientation', 'angleSRxaxis', 'distance' /)  ! 9 parameters
 ! character(len=200)         :: buildingParamNames(7) = (/'hEmis', 'V_stack', 'D_stack', 'buildingHeight', 'buildingLength', 'buildingWLRatio', 'distance' /)  ! 7 parameters
 ! character(len=200)         :: buildingParamNames(4) = (/'V_stack', 'buildingHeight', 'hEmis', 'distance' /)  ! simple test with 4 parameters
@@ -75,23 +71,23 @@ Type Tbuilding
    real      :: width                                     ! building width [m]
    real      :: height                                    ! building height [m]
    real      :: orientation                               ! building orientation (degrees w.r.t. North)
-   real, allocatable :: buildingFactFunction(:,:)         ! building effect function (function of source receptor angle, source receptor distance)
+   real, allocatable :: buildingFactFunction(:,:)         ! building effect function (function of source receptor angle, source receptor distance)  
    integer   :: type                                      ! building type for determining distance function for building effect [-]; type = 0 -> no building effect
-End Type Tbuilding
+End Type Tbuilding 
 
 type TbuildingEffect
     integer           :: nParam                           ! number of building parameters (read from file)
-    real, allocatable :: classdefinitionArray(:)          ! array with representative class values for each parameter
+    real, allocatable :: classdefinitionArray(:)          ! array with representative class values for each parameter 
                                                           ! (stored in one-dimensional array: [nClass(1) values for p1, nClass(2) values for p2, ...])
-    integer           :: nClass(mParam)                   ! number of classes for each parameter
-    real              :: minClass(mParam)                 ! minimum of class values for each parameter
-    real              :: maxClass(mParam)                 ! maximum of class values for each parameter
+    integer           :: nClass(mParam)                   ! number of classes for each parameter 
+    real              :: minClass(mParam)                 ! minimum of class values for each parameter                                                                  
+    real              :: maxClass(mParam)                 ! maximum of class values for each parameter                                                                  
     real, allocatable :: buildingFactArray(:)             ! building effect factors for each parameter/class, stored in a one-dimensional array
     real, allocatable :: buildingFactAngleSRxaxis(:)      ! source receptor angles (w.r.t. x-axis) where to evaluate 2D function of building effect
     real, allocatable :: buildingFactDistances(:)         ! distances where to evaluate 2D function of building effect
 end type TbuildingEffect
 
-contains
+contains 
 
 !-----------------------------------------------------------------------------------
 subroutine ops_building_file_names(error)
@@ -129,16 +125,16 @@ CHARACTER*512, PARAMETER   :: ROUTINENAAM = 'ops_building_read_tables'
 ! Output:
 type(tbuildingEffect), intent(out) :: buildingEffect           ! structure containing data for building effect
 type(Terror),          intent(out) :: error                    ! error handling record
-
-! Local:
+    
+! Local: 
 integer               :: nClassProd                            ! product of number of classes for each parameter
 
 ! Read classes for building parameters:
-call ops_building_read_classes(mParam, mClass, buildingEffect%classdefinitionArray, buildingEffect%buildingFactAngleSRxaxis, buildingEffect%buildingFactDistances, &
+call ops_building_read_classes(mParam, mClass, buildingEffect%classdefinitionArray, buildingEffect%buildingFactAngleSRxaxis, buildingEffect%buildingFactDistances, & 
                                buildingEffect%nParam, buildingEffect%nClass, buildingEffect%minClass, buildingEffect%maxClass, nClassProd, error)
 if (error%haserror) goto 9999
-
-! Read building factors:
+           
+! Read building factors:           
 call ops_building_read_building_factors(mClass, buildingEffect%nParam, nClassProd, buildingEffect%nClass, buildingEffect%buildingFactArray, error)
 if (error%haserror) goto 9999
 
@@ -149,31 +145,31 @@ RETURN
 end subroutine ops_building_read_tables
 
 !-----------------------------------------------------------------------------------
-subroutine ops_building_read_classes(mParam, mClass, &
+subroutine ops_building_read_classes(mParam, mClass, & 
            classdefinitionArray, buildingFactAngleSRxaxis, buildingFactDistances, nParam, nClass, minClass, maxClass, nClassProd, error)
-
+           
 use m_commonfile, only: buildingClassFilename, fu_tmp
 use m_error
 use m_fileutils
 
     CHARACTER*512, PARAMETER   :: ROUTINENAAM = 'ops_building_read_classes'
-
+    
     ! Input:
     integer,  intent(in)       :: mParam                           ! maximal number of parameters
     integer,  intent(in)       :: mClass                           ! maximal number of classes for any parameter
 
     ! Output:
-    real, allocatable, intent(out) :: classdefinitionArray(:)      ! array with representative class values for each parameter
+    real, allocatable, intent(out) :: classdefinitionArray(:)      ! array with representative class values for each parameter 
                                                                    ! (stored in one-dimensional array: [nClass(1) values for p1, nClass(2) values for p2, ...])
-    real, allocatable, intent(out) :: buildingFactAngleSRxaxis(:)  ! source rceptor angles (w.r.t. x-axis) where to evaluate 2D function of building effect
-    real, allocatable, intent(out) :: buildingFactDistances(:)     ! distances where to evaluate 2D function of building effect
+    real, allocatable, intent(out) :: buildingFactAngleSRxaxis(:)  ! source rceptor angles (w.r.t. x-axis) where to evaluate 2D function of building effect                                                                 
+    real, allocatable, intent(out) :: buildingFactDistances(:)     ! distances where to evaluate 2D function of building effect                                                                 
     integer, intent(out)       :: nParam                           ! actual number of parameters (read from file)
-    integer, intent(out)       :: nClass(mParam)                   ! number of classes for each parameter
-    real   , intent(out)       :: minClass(mParam)                 ! minimum of class values for each parameter
-    real   , intent(out)       :: maxClass(mParam)                 ! maximum of class values for each parameter
+    integer, intent(out)       :: nClass(mParam)                   ! number of classes for each parameter 
+    real   , intent(out)       :: minClass(mParam)                 ! minimum of class values for each parameter                                                                  
+    real   , intent(out)       :: maxClass(mParam)                 ! maximum of class values for each parameter                                                                  
     integer, intent(out)       :: nClassProd                       ! product of number of classes for each parameter
     type(Terror), intent(out)  :: error                            ! error handling record
-
+    
     ! Local:
     real                       :: classdefinitionArrayTemp(mClass*mParam)  ! temporary array for reading classdefinitionArray
     integer                    :: iParam                           ! index of parameter
@@ -182,16 +178,16 @@ use m_fileutils
     character(100)             :: pName                            ! parameter name
     real                       :: pVals( mClass )                  ! representative parameter values for classes for one parameter
     integer                    :: n                                ! number of values read from file
-    character(100)             :: paramNames(mParam)               ! parameter names
+    character(100)             :: paramNames(mParam)               ! parameter names 
     integer                    :: nClassSum                        ! sum of number of classes for each parameter
 
     ! Initialisation:
     iParam = 0
     ilast  = 0  ! index of last value in classdefinitionArrayTemp
-
+    
     ! Open file:
     IF (.NOT. sysopen(fu_tmp, buildingClassFilename, 'r', 'class definition file for building effect', error)) GOTO 9999
-
+    
     ! Loop over lines in file:
     do
         ! Read line from file and split into name and values:
@@ -206,30 +202,30 @@ use m_fileutils
             iParam = iParam + 1
             if (iParam .gt. mParam) then
                call SetError('Too many parameters in file ',error)
-               call ErrorParam('maximal number of parameters allowed', mParam, error)
+               call ErrorParam('maximal number of parameters allowed', mParam, error) 
                goto 9998
             endif
-
+            
             ! Set number of classes for this parameter and fill paramNames and classdefinitionArrayTemp:
             nClass(iParam)     = n
-            paramNames(iParam) = pName
+            paramNames(iParam) = pName 
             classdefinitionArrayTemp(ilast+1:ilast+n) = pVals(1:n)   !  note that pVals has to be sorted .. check?
-            minClass(iParam) = minval(pVals(1:n))
-            maxClass(iParam) = maxval(pVals(1:n))
+            minClass(iParam) = minval(pVals(1:n))  
+            maxClass(iParam) = maxval(pVals(1:n))  
             ilast = ilast + n
         endif
     enddo
 500 continue
     close( fu_tmp )
-
+    
     ! Now we know the number of parameters and the number of classes:
     nParam     = iParam
-    nClassSum  = sum(nClass(1:nParam))
-    nClassProd = product(nClass(1:nParam))
-
+    nClassSum  = sum(nClass(1:nParam)) 
+    nClassProd = product(nClass(1:nParam))   
+    
     ! Check:
     if (ilast .ne. nClassSum) then
-       write(*,*) 'Internal programming error in ', ROUTINENAAM
+       write(*,*) 'Internal programming error in ', ROUTINENAAM  
        write(*,*) 'ilast = ',ilast, ' nClassSum = ',nClassSum
        write(*,*) 'ilast must be nClassSum  '
        stop
@@ -238,31 +234,31 @@ use m_fileutils
     ! Check parameter names:
     if (any(paramNames(1:nParam) .ne. buildingParamNames)) then
         call SetError('Error in parameter names ',error)
-        call ErrorParam('parameter names in file ', paramNames(1:nParam), error)
-        call ErrorParam('expected parameter names', buildingParamNames, error)
+        call ErrorParam('parameter names in file ', paramNames(1:nParam), error) 
+        call ErrorParam('expected parameter names', buildingParamNames, error) 
         goto 9999
     endif
-
-    ! **** Allocate memory and fill class definition table *****
-
+    
+    ! **** Allocate memory and fill class definition table *****    
+    
     allocate(classdefinitionArray(nClassSum))
-    classdefinitionArray = classdefinitionArrayTemp(1:nClassSum)
-
+    classdefinitionArray = classdefinitionArrayTemp(1:nClassSum) 
+    
     ! Allocate and fill array with source rceptor angles (w.r.t. x-axis) used to evaluate building factors
     ! (one but last parameter in classdefinitionArray):
-    allocate(buildingFactAngleSRxaxis(nClass(nParam-1)))
+    allocate(buildingFactAngleSRxaxis(nClass(nParam-1))) 
     buildingFactAngleSRxaxis = classdefinitionArray(nClassSum - nClass(nParam) - nClass(nParam-1) + 1 : nClassSum - nClass(nParam))
 
     ! Allocate and fill array with distances used to evaluate building factors
     ! (last parameter in classdefinitionArray):
-    allocate(buildingFactDistances(nClass(nParam)))
+    allocate(buildingFactDistances(nClass(nParam))) 
     buildingFactDistances = classdefinitionArray(nClassSum - nClass(nParam) + 1 : nClassSum)
 
     !write(*,*) 'ops_building_read_classes/buildingFactDistances:',buildingFactDistances
     !write(*,*) 'ops_building_read_classes/buildingFactAngleSRxaxis:',buildingFactAngleSRxaxis
-
+    
     RETURN
-
+    
 9998 CALL ErrorParam('line read from file', trim(line), error)
 
 9999 CALL ErrorParam('file name', buildingClassFilename, error)
@@ -277,22 +273,22 @@ use m_commonfile, only: buildingFactFilename, fu_tmp
 use m_error
 use m_fileutils
 
-   ! **** Read factors for building effects table from file *****
+   ! **** Read factors for building effects table from file *****  
 
-    CHARACTER*512, PARAMETER   :: ROUTINENAAM = 'ops_building_read_building_factors'
+    CHARACTER*512, PARAMETER   :: ROUTINENAAM = 'ops_building_read_building_factors'   
 
     ! Input:
     integer,  intent(in)       :: mClass                           ! maximal number of classes for any parameter
     integer,  intent(in)       :: nParam                           ! actual number of parameters (read from file)
     integer,  intent(in)       :: nClassProd                       ! product of number of classes for each parameter
-    integer,  intent(in)       :: nClass(:)                        ! number of classes for each parameter
+    integer,  intent(in)       :: nClass(:)                        ! number of classes for each parameter 
 
-
+   
     ! Output:
     real, allocatable, intent(out) :: buildingFactArray(:)         ! building effect factors for each parameter/class, stored in a one-dimensional array
     type(Terror), intent(out)      :: error                        ! error handling record
 
-    ! Local:
+    ! Local:    
     character(1000)            :: line                             ! line read from file
     integer                    :: iLine                            ! index of line read (includes header line)
     integer                    :: iParam                           ! index of parameter
@@ -306,80 +302,80 @@ use m_fileutils
     logical                    :: read_unformatted = .true.        ! read unformatted file (is much faster than formatted file)
 
     ! Allocate memory for  building effects table:
-    allocate(buildingFactArray(nClassProd))
+    allocate(buildingFactArray(nClassProd)) 
 
     if (read_unformatted) then
        ! Open file, read array with building factors and close file:
        IF (.NOT. sysopen(fu_tmp, buildingFactFilename, 'rb', 'file with building effect factors', error)) GOTO 9999
        read(fu_tmp) buildingFactArray
        close(fu_tmp)
-
+       
     else
        !------------------------------------------------------------------------------------------------------
        ! This part of the subroutine is not used anymore in OPS; there is a separate program to convert
        ! the ASCII table into an unformatted file which read musch faster. This separate program uses
        ! the code below.
-       !------------------------------------------------------------------------------------------------------
-
+       !------------------------------------------------------------------------------------------------------           
+           
        ! Construct format for write to screen
        fmt = '(i6,": ",  (1x,i4),1x,f8.3)'
        write(fmt(10:11),'(i2)') nParam
-
+       
        ! Open file:
        IF (.NOT. sysopen(fu_tmp, buildingFactFilename, 'r', 'file with building effect factors', error)) GOTO 9999
-
+       
        ! Initialise:
        iClassExpected = 1
-
+       
        ! Read file until end-of-file:
-       iLine = 0
+       iLine = 0  
        do
            read( fu_tmp, "(a)", end=510 ) line
            ! print *,line
-
+           
            ! Skip empty line:
            if (len_trim(line) > 0) then
               iLine = iLine + 1
               if (iLine .eq. 1) then
                  ! Header line
-                 read( line, *) colNames(1:nParam+1 )
+                 read( line, *) colNames(1:nParam+1 ) 
                  !write(*,*) 'Table '
-                 !write(*,'(99(1x,a))') colNames(1:nParam+1 )
-
+                 !write(*,'(99(1x,a))') colNames(1:nParam+1 )  
+                 
                     ! Check parameter names:
                     if (any(colNames(1:nParam) .ne. buildingParamNames)) then
                         call SetError('Error in parameter names ',error)
-                        call ErrorParam('parameter names in file ', colNames(1:nParam), error)
-                        call ErrorParam('expected parameter names', buildingParamNames, error)
+                        call ErrorParam('parameter names in file ', colNames(1:nParam), error) 
+                        call ErrorParam('expected parameter names', buildingParamNames, error) 
                         goto 9999
                     endif
-
+       
               else
                 ! Check number of lines read:
                 if (iLine-1 .gt. nClassProd) then
                    call SetError('number of lines read from file larger than expected ',error)
-                   call ErrorParam('line number ', iLine, error)
+                   call ErrorParam('line number ', iLine, error) 
                    call ErrorParam('number of lines expected', nClassProd+1, error)   ! including header line
                    goto 9998
                 endif
-
-                ! Split line into nParam integer class indices and (last value) buiding effect factor:
-                call split2( line, nParam, iClassRead, buildingFactInput)
-
-                ! Check class indices read from file:
+              
+                ! Split line into nParam integer class indices and (last value) buiding effect factor: 
+                call split2( line, nParam, iClassRead, buildingFactInput) 
+              
+                ! Check class indices read from file: 
                 if (any(iClassExpected .ne. iClassRead)) then
                    call SetError('Incorrect set of class indices.','Last index must vary fastest, then last but one, ...',error)
-                   call ErrorParam('line number ', iLine, error)
-                   call ErrorParam('expected class indices', iClassExpected, error)
+                   call ErrorParam('line number ', iLine, error) 
+                   call ErrorParam('expected class indices', iClassExpected, error) 
                    goto 9998
                 endif
-
+                
                 ! Shift to next set of class indices ((must be in order for routine SILUPM: last index varies fast, then last but one, ...):
                 shiftNext = .true.
                 iParam = nParam
-                do while (shiftNext .and. iParam .ge. 1)
+                do while (shiftNext .and. iParam .ge. 1) 
                    iClassExpected(iParam) = iClassExpected(iParam) + 1
-
+                   
                    ! If this parameter exceeds the number of classes -> reset to 1 and shift to next parameter:
                    if (iClassExpected(iParam) .gt. nClass(iParam)) then
                       iClassExpected(iParam) = 1
@@ -389,43 +385,43 @@ use m_fileutils
                    endif
                    iParam = iParam - 1
                 enddo
-
+                
                 ! Fill building effect factor into buildingFactArray;
                 ! order of lines is essential here and has been checked above (iClassRead = iClassExpected). See definition SILUPM for 2D array ((y(x1(i), x2(j)), j=1:NTAB(2)), i=1:NTAB(1))
                 ! if (iLine .le. 3) write(*,fmt) iLine-1,iClassRead(1:nParam),buildingFactInput
-                buildingFactArray(iLine-1) = buildingFactInput
-              endif ! iLine .eq. 1
+                buildingFactArray(iLine-1) = buildingFactInput  
+              endif ! iLine .eq. 1  
            endif ! len_trim(line) > 0
        enddo
 510    continue
        close( fu_tmp )
-
+       
        ! write(*,'(a)') '............................'
        ! write(*,fmt) iLine-1,iClassRead(1:nparam),buildingFactInput
-
+       
        ! Check number of lines read:
        if (iLine-1 .ne. nClassProd) then
           call SetError('number of lines read from file smaller than expected ',error)
-          call ErrorParam('line number ', iLine, error)
+          call ErrorParam('line number ', iLine, error) 
           call ErrorParam('number of lines expected', nClassProd+1, error)  ! including header line
           goto 9999
        endif
     endif  ! read_unformatted
-
+    
     ! **** Printing/checking building effects table *****
-    if (.FALSE.) then
+    if (.FALSE.) then  
        do i = 1,nClassProd
           print *, i, buildingFactArray(i)
        enddo
     endif
 
     RETURN
-
+    
 9998 CALL ErrorParam('line read from file', trim(line), error)
-
+    
 9999 CALL ErrorParam('file name', buildingFactFilename, error)
 CALL ErrorCall(ROUTINENAAM, error)
-
+       
 end subroutine ops_building_read_building_factors
 
 !-----------------------------------------------------------------------------------------
@@ -434,44 +430,44 @@ subroutine ops_building_get_function(nParam, valueArray, nClass, classdefinition
 
   ! Get 2D building effect function (function of source-receptor angle and distance to source) for a specific set of building parameter values in valueArray;
   ! interpolate this factor from factors in buildingFactArray, based on the location of valueArray within the table classdefinitionArray.
-
+  
   use m_error
-
+  
   CHARACTER*512, PARAMETER   :: ROUTINENAAM = 'ops_building_get_function'
-
+  
   ! Input:
   integer,  intent(IN)    :: nParam                                  ! number of parameters
-  integer,  intent(IN)    :: nClass(nParam)                          ! number of classes for each parameter
+  integer,  intent(IN)    :: nClass(nParam)                          ! number of classes for each parameter 
   real,     intent(IN)    :: classdefinitionArray(:)                 ! array with representative class values for each parameter
   real,     intent(IN)    :: buildingFactAngleSRxaxis(:)             ! source-receptor angles (w.r.t. x-axis) where to evaluate 2D building effect function
   real,     intent(IN)    :: buildingFactDistances(:)                ! distances where to evaluate 2D building effect function
   real,     intent(IN)    :: buildingFactArray(:)                    ! building effect factors for each parameter/class.
-
+  
   ! Input/output:
   real,     intent(INOUT) :: valueArray(nParam)                      ! array with set of parameter values for specific building (output: values outside table are moved to boundaries of table)
-
+  
   ! Output:
   real, allocatable, intent(OUT) :: buildingFactFunction(:,:)        ! 2D buiding effect function for specific building (function of angle, distance)
   type(Terror),      intent(out) :: error                            ! error handling record
 
-  ! Arguments for SILUPM
+  ! Arguments for SILUPM    
   ! Local variables for SILUPM
-  integer                 :: NTAB(2*nParam+1)
-  integer                 :: NDEG(nParam)
-  integer                 :: LUP(nParam)
+  integer                 :: NTAB(2*nParam+1)   
+  integer                 :: NDEG(nParam)       
+  integer                 :: LUP(nParam)        
   integer                 :: IOPT(3)            ! options used for output of SILUPM
-  real                    :: EOPT(6*nParam)     ! error estimate
-
-  ! Local:
-  integer                 :: iParam             ! parameter index
+  real                    :: EOPT(6*nParam)     ! error estimate  
+   
+  ! Local:   
+  integer                 :: iParam             ! parameter index    
   integer                 :: ix, iy             ! loop indices
-
-   ! print *, "Building effects table from within subroutine getbuildingEffect"
+  
+   ! print *, "Building effects table from within subroutine getbuildingEffect"    
    ! do ix = 1,size(buildingFactArray)
    !    print *, ix, buildingFactArray(ix)
    ! enddo
-
-!  ! Interpolate multidimensional table:
+  
+!  ! Interpolate multidimensional table:  
 !  ! CALL SILUPM(NDIM, X, Y, NTAB, XT, YT, NDEG, LUP, IOPT, EOPT)
 !  ! NDIM = nParam
 !  ! X = ValueArray (input for a specific building)
@@ -483,23 +479,23 @@ subroutine ops_building_get_function(nParam, valueArray, nClass, classdefinition
 !  ! LUP  = type of lookup method (binary search or sequntial search, see doc SILUPM)
 !  ! IOPT = options used for output
 
-
+  
   NTAB(1:nParam) = nClass(1:nParam)
   NTAB(nParam+1) = 0   ! as required by SILUPM
   NDEG = 1
   LUP  = 1 ! binary search
-
+  
   ! Set IOPT:
-  IOPT(1) = 1
+  IOPT(1) = 1 
   !IOPT(2) = 0
   !IOPT(3) = 0
-  IOPT(2) = 6*nParam; ! size(EOPT)
+  IOPT(2) = 6*nParam; ! size(EOPT) 
   IOPT(3) = 0
-
+  
   ! Loop over distances for building effect function:
-  allocate(buildingFactFunction(size(buildingFactAngleSRxaxis),size(buildingFactDistances)))
+  allocate(buildingFactFunction(size(buildingFactAngleSRxaxis),size(buildingFactDistances))) 
 
-  ! write(*,*) '==================================================================================='
+  ! write(*,*) '==================================================================================='  
   ! write(*,*) 'ops_building_get_function/valueArray = ',ValueArray
   ! write(*,*) 'ops_building_get_function/buildingFactAngleSRxaxis: ',     buildingFactAngleSRxaxis
   ! write(*,*) 'ops_building_get_function/buildingFactDistances: ',     buildingFactDistances
@@ -510,34 +506,34 @@ subroutine ops_building_get_function(nParam, valueArray, nClass, classdefinition
   ! Loop over angles and distances for building effect function:
   do iy = 1,size(buildingFactDistances)
      do ix = 1,size(buildingFactAngleSRxaxis)
-
+  
         ! Put current angle, distance as last two values in valueArray:
-        valueArray(nParam-1) = buildingFactAngleSRxaxis(ix)
-        valueArray(nParam)   = buildingFactDistances(iy)
-
+        valueArray(nParam-1) = buildingFactAngleSRxaxis(ix) 
+        valueArray(nParam)   = buildingFactDistances(iy) 
+        
         ! Look up building factor in table and put factor into buildingFactFunction(ix,iy):
         CALL SILUPM(nParam, ValueArray, buildingFactFunction(ix,iy), NTAB, classdefinitionArray, buildingFactArray, NDEG, LUP, IOPT, EOPT)
      enddo
   enddo
-
+  
   ! do ix = 1,size(buildingFactAngleSRxaxis)
   !    write(*,*) 'ops_building_get_function/buildingFactFunction for angle ',buildingFactAngleSRxaxis(ix),'degrees : ', buildingFactFunction(ix,:)
   ! enddo
-  ! write(*,*) '==================================================================================='
-
+  ! write(*,*) '==================================================================================='  
+  
   if (IOPT(1) .ne. 0) then
      if (IOPT(1) .eq. 1) then
         call SetError('Error in look up in table of building factors; parameter values outside domain of the table ',error)
      else
-        call ErrorParam('error status (see documentation netlib/SILUPM) ', IOPT(1), error)
+        call ErrorParam('error status (see documentation netlib/SILUPM) ', IOPT(1), error) 
      endif
-     call ErrorParam('parameter names  ', buildingParamNames, error)
-     call ErrorParam('parameter values ', valueArray, error)
+     call ErrorParam('parameter names  ', buildingParamNames, error) 
+     call ErrorParam('parameter values ', valueArray, error) 
      goto 9999
   endif
 
   RETURN
-
+  
 9999 CALL ErrorCall(ROUTINENAAM, error)
 
 end subroutine ops_building_get_function
@@ -556,11 +552,11 @@ end subroutine ops_building_get_function
 ! BRANCH - SEQUENCE   : %B% - %S%
 ! DATE - TIME         : %E% - %U%
 ! WHAT                : %W%:%E%
-! AUTHOR              : Sjoerd van Ratingen
+! AUTHOR              : OPS-support   
 ! FIRM/INSTITUTE      : RIVM/LLO
 ! LANGUAGE            : FORTRAN-77/90
-! DESCRIPTION         : Returns closest and interpolated building effect based on "buildingEffectTable",
-! DESCRIPTION         : given a source catergory and a distance from source to receptor.
+! DESCRIPTION         : Returns closest and interpolated building effect based on "buildingEffectTable", 
+! DESCRIPTION         : given a source catergory and a distance from source to receptor. 
 ! EXIT CODES          :
 ! FILES I/O DEVICES   :
 ! SYSTEM DEPENDENCIES : HP Fortran
@@ -575,11 +571,11 @@ IMPLICIT NONE
 ! Note the cut-off value of 50 m from the source.
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM                !
+CHARACTER*512                                    :: ROUTINENAAM                ! 
 PARAMETER    (ROUTINENAAM = 'ops_building_get_factor')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-INTEGER, INTENT(IN)         :: buildingType                                    ! = 0 -> no building effect (factor = 1)
+INTEGER, INTENT(IN)         :: buildingType                                    ! = 0 -> no building effect (factor = 1) 
 REAL*4, INTENT(IN)          :: angle_SR_xaxis                                  ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
 REAL*4, INTENT(IN)          :: dist                                            ! distance between source and receptor
 REAL*4, INTENT(IN)          :: buildingFactDistances(:)                        ! distances for which building effect function has been computed
@@ -601,7 +597,7 @@ ELSE
    distcor = max(dist,buildingFactDistances(1))
 
    ! If source receptor distance larger than largest distance in table -> no building effect; else interpolate building factor from 2d table:
-
+   
    if (distcor > buildingFactDistances(size(buildingFactDistances))) then
       buildingFact = 1.0
    else
@@ -630,24 +626,24 @@ real   , intent(in) :: y             ! y value where to interpolate
 integer ::  i,ix,iy                  ! array indices
 real    ::  x_intp,y_intp            ! 1D interpolation factors
 
-! Check if outside tabel boundaries (normally this should not occur, because values have been shifted
+! Check if outside tabel boundaries (normally this should not occur, because values have been shifted 
 ! inside table boundaries before call -> normal error handling not needed):
 if (x < tabx(1) .or. x > tabx(nx)) then
    write(*,*) ' '
-   write(*,*) ' error: x index outside table'
+   write(*,*) ' error: x index outside table' 
    write(*,*) ' boundaries: ',tabx(1), tabx(nx)
    write(*,*) ' value     : ',x
    stop
 endif
 if (y < taby(1) .or. y > taby(ny)) then
    write(*,*) ' '
-   write(*,*) ' error: y index outside table'
+   write(*,*) ' error: y index outside table' 
    write(*,*) ' boundaries: ',taby(1), taby(ny)
    write(*,*) ' value     : ',y
    stop
 endif
-
-! Find index ix, such that tabx(ix) < x <= tabx(ix+1)
+   
+! Find index ix, such that tabx(ix) < x <= tabx(ix+1) 
 ! Note: first interval includes left boundary: tabx(1) <= x <= tabx(2)
 do i = 1,nx-1
    if (x <= tabx(i+1)) then
@@ -676,58 +672,58 @@ end function interpol_2d
 
 !-------------------------------------------------------------------------------------------
 subroutine split1( mClass, line, pName , pVals, n )
-
+    
     implicit none
-
+    
     ! Input:
     integer,      intent(IN) :: mClass      ! maximal number of classes for any parameter
     character(*), intent(in) :: line        ! line read from file with parameter names and parameter values
-
+    
     ! Output:
     character(100), intent(out) :: pName     ! parameter name
     real,           intent(out) :: pVals(*)  ! parameter values
     integer,        intent(out) :: n         ! number of parameter values read
-
+    
     ! Local
     character*100              :: cbuf( mClass )
     integer :: m
 
-    ! Read word for word from line:
+    ! Read word for word from line:    
     n = 1
     do
         read( line, *, end=100) cbuf( 1 : n)   !  !! (See Appendix for why buf is used here)
         read(cbuf(1),*) pName
         do m = 2,n
-          read(cbuf(m),*) pVals(m-1)
+          read(cbuf(m),*) pVals(m-1) 
           !print *, pVals(m)
         enddo
         n = n + 1
     enddo
 100 continue
     n = n - 1 ! length of cbuf
-    n = n - 1 ! number of reals behind first column with parameter name
+    n = n - 1 ! number of reals behind first column with parameter name 
 end subroutine split1
 
 !-------------------------------------------------------------------------------------------
-subroutine split2( line, nParam, iClassRead, buildingFactInput)
-
+subroutine split2( line, nParam, iClassRead, buildingFactInput) 
+    
     implicit none
-
+    
     ! Input:
     character(*), intent(in) :: line                ! line read from file with class indices for each parameter and corresponding building effect factor
     integer, intent(in)      :: nParam              ! number of parameters
-
+    
     ! Output:
     integer, intent(out)     :: iClassRead(nParam)      ! class indices for each parameter
     real,    intent(out)     :: buildingFactInput   ! buiding effect factor, read from input
-
+    
     ! Local variables:
     character*8              :: cbuf( nParam+1 )
     integer                  :: iParam
 
-    ! Read data from line:
+    ! Read data from line:    
     read( line, *) (iClassRead(iParam), iParam = 1,nParam), buildingFactInput
-
+    
  end subroutine split2
-
+ 
  end module m_ops_building

--- a/m_ops_building.f90
+++ b/m_ops_building.f90
@@ -576,14 +576,14 @@ PARAMETER    (ROUTINENAAM = 'ops_building_get_factor')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER, INTENT(IN)         :: buildingType                                    ! = 0 -> no building effect (factor = 1) 
-REAL*4, INTENT(IN)          :: angle_SR_xaxis                                  ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
-REAL*4, INTENT(IN)          :: dist                                            ! distance between source and receptor
-REAL*4, INTENT(IN)          :: buildingFactDistances(:)                        ! distances for which building effect function has been computed
-REAL*4, INTENT(IN)          :: buildingFactAngleSRxaxis(:)                     ! source receptor angles (w.r.t. x-axis) for which building effect function has been computed
-REAL*4, INTENT(IN)          :: buildingFactFunction(:,:)                       ! 2D building effect function (function of angle, distance)
+real,   INTENT(IN)          :: angle_SR_xaxis                                  ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
+real,   INTENT(IN)          :: dist                                            ! distance between source and receptor
+real,   INTENT(IN)          :: buildingFactDistances(:)                        ! distances for which building effect function has been computed
+real,   INTENT(IN)          :: buildingFactAngleSRxaxis(:)                     ! source receptor angles (w.r.t. x-axis) for which building effect function has been computed
+real,   INTENT(IN)          :: buildingFactFunction(:,:)                       ! 2D building effect function (function of angle, distance)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4, INTENT(OUT) :: buildingFact                                            ! building effect factor interpolated between (angle, distance) values in buildingFactFunction
+real,   INTENT(OUT) :: buildingFact                                            ! building effect factor interpolated between (angle, distance) values in buildingFactFunction
 
 ! LOCAL VARIABLES
 REAL    :: distcor                                                             ! corrected distance for distances below cut-off distance; for these distances take the effect at the cut-off distance

--- a/m_ops_emis.f90
+++ b/m_ops_emis.f90
@@ -413,11 +413,11 @@ PARAMETER    (ROUTINENAAM = 'check_source')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: nr                         ! record number of source file
 CHARACTER*(*), INTENT(IN)                        :: varnaam                    ! variable to be checked
-REAL*4,    INTENT(IN)                            :: onder                      ! lower limit
-REAL*4,    INTENT(IN)                            :: boven                      ! upper limit
+real,      INTENT(IN)                            :: onder                      ! lower limit
+real,      INTENT(IN)                            :: boven                      ! upper limit
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: varwaarde                  ! (adapted) value of variable
+real,      INTENT(INOUT)                         :: varwaarde                  ! (adapted) value of variable
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 ! LOCAL VARIABLES
@@ -541,9 +541,9 @@ PARAMETER    (ROUTINENAAM = 'check_source2')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: varnaam                    ! variable to be checked
-REAL*4,    INTENT(IN)                            :: onder                      ! lower limit
-REAL*4,    INTENT(IN)                            :: boven                      ! upper limit
-REAL*4,    INTENT(IN)                            :: varwaarde                  ! value of variable
+real,      INTENT(IN)                            :: onder                      ! lower limit
+real,      INTENT(IN)                            :: boven                      ! upper limit
+real,      INTENT(IN)                            :: varwaarde                  ! value of variable
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
@@ -589,9 +589,9 @@ PARAMETER    (ROUTINENAAM = 'check_source3')
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: warning1                   ! first part of warning
 CHARACTER*(*), INTENT(IN)                        :: varnaam                    ! variable to be checked
-REAL*4,    INTENT(IN)                            :: onder                      ! lower limit
-REAL*4,    INTENT(IN)                            :: boven                      ! upper limit
-REAL*4,    INTENT(IN)                            :: varwaarde                  ! value of variable
+real,      INTENT(IN)                            :: onder                      ! lower limit
+real,      INTENT(IN)                            :: boven                      ! upper limit
+real,      INTENT(IN)                            :: varwaarde                  ! value of variable
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record

--- a/m_ops_emis.f90
+++ b/m_ops_emis.f90
@@ -1,26 +1,22 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
-!-------------------------------------------------------------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 module m_ops_emis
 
-! Emission module, contains subroutines to read emissions.
-
+! Emission module, contains subroutines to read emissions. 
+ 
 implicit none
 
 PRIVATE ! default for module
@@ -46,7 +42,7 @@ USE m_fileutils
 IMPLICIT NONE
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                 
 PARAMETER    (ROUTINENAAM = 'ops_emis_read_header')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -69,14 +65,14 @@ INTEGER                                          :: brn_version_read           !
 
 !-------------------------------------------------------------------------------------------------------------------------------
 
-! Initialisation:
+! Initialisation: 
 numbron     = 0
 nrec        = 0
 end_of_info = .FALSE.
 
 ! Default (if no ! BRN-VERSION can be found) -> old brn-file, no stack parameters:
 brn_version = 0
-VsDs_opt    = .FALSE.
+VsDs_opt    = .FALSE. 
 
 ! Read first header line:
 CALL sysread(fu_bron, cbuf, end_of_info, error)
@@ -107,7 +103,7 @@ IF (cbuf(1:1) .EQ. "!") THEN
      call SetError('Error while reading BRN-VERSION version_number in first line of header', error)
      goto 9999
   endif
-
+  
   ! Read rest of header lines:
   DO WHILE (.NOT. end_of_info)
     CALL sysread(fu_bron, cbuf, end_of_info, error)
@@ -115,7 +111,7 @@ IF (cbuf(1:1) .EQ. "!") THEN
     IF (error%haserror) GOTO 9999
     IF (cbuf(1:1) .NE. "!") THEN
        end_of_info = .TRUE.
-
+      
        ! First real emission record has been reached, so we backspace 1 line:
        backspace(fu_bron)
        nrec = nrec - 1
@@ -137,7 +133,7 @@ SUBROUTINE ops_emis_read_annual1(fu_bron, icm, check_psd, presentcode, brn_versi
 
 ! Read one data line from the emission file (brn-file; brn << bron = source)) and return emission parameters.
 ! Emission parameters that lie outside a specified range generate an error.
-! This subroutine supports old type of emission files (with no BRN-VERSION header or BRN-VERSION 1
+! This subroutine supports old type of emission files (with no BRN-VERSION header or BRN-VERSION 1 
 ! both in fixed format (old type of brn-files) and free format and extended free format (with V_stack, D_stack, Ts_stack) .
 
 USE m_error
@@ -151,7 +147,7 @@ use m_ops_building
 IMPLICIT NONE
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                 
 PARAMETER    (ROUTINENAAM = 'ops_emis_read_annual1')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -169,11 +165,11 @@ LOGICAL, INTENT(IN)                            :: VsDs_opt                   ! r
 ! SUBROUTINE ARGUMENTS - INPUT/OUTPUT
 INTEGER, INTENT(INOUT)                         :: nrec                       ! record number of source file
 INTEGER, INTENT(INOUT)                         :: numbron                    ! number of (selected) source
-LOGICAL, INTENT(INOUT)                         :: building_present1          ! at least one building is present in the source file
+LOGICAL, INTENT(INOUT)                         :: building_present1          ! at least one building is present in the source file   
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER, INTENT(OUT)                           :: mm                         ! source identification number [-]
-REAL   , INTENT(OUT)                           :: x                          ! x coordinate of source location (RDM [m])
+REAL   , INTENT(OUT)                           :: x                          ! x coordinate of source location (RDM [m])                 
 REAL   , INTENT(OUT)                           :: y                          ! y coordinate of source location (RDM [m])
 REAL   , INTENT(OUT)                           :: qob                        ! emission strength [g/s]
 REAL   , INTENT(OUT)                           :: qww                        ! heat content [MW]
@@ -194,8 +190,8 @@ TYPE (TError), INTENT(OUT)                     :: error                      ! E
 
 ! LOCAL VARIABLES
 INTEGER                                        :: ierr                       ! I/O error value
-REAL                                           :: gl                         ! x coordinate of source location (longitude [degrees])
-REAL                                           :: gb                         ! y coordinate of source location (latitude [degrees])
+REAL                                           :: gl                         ! x coordinate of source location (longitude [degrees])                 
+REAL                                           :: gb                         ! y coordinate of source location (latitude [degrees])                 
 CHARACTER*512                                  :: cbuf                       ! character buffer, used to store an emission record
 real                                           :: Ts_stack_C                 ! temperature of effluent from stack [C]
 
@@ -217,53 +213,53 @@ building%orientation = -999.0
 
 ! Read string cbuf from emission file:
 CALL sysread(fu_bron, cbuf, end_of_file, error)
-IF (error%haserror) GOTO 9999
+IF (error%haserror) GOTO 9999 
 
-IF (.NOT. end_of_file) THEN
+IF (.NOT. end_of_file) THEN 
    IF (brn_version .GE. 1) THEN
       !*************************************************************************
-      !  New brn-file, free format
-      !  BRN-VERSION 1 -> no D_stack, V_stack, Ts_stack
-      !  BRN-VERSION 2 -> include D_stack, V_stack, Ts_stack
-      !  BRN-VERSION 3 -> include D_stack, V_stack, Ts_stack, building%type
+      !  New brn-file, free format 
+      !  BRN-VERSION 1 -> no D_stack, V_stack, Ts_stack 
+      !  BRN-VERSION 2 -> include D_stack, V_stack, Ts_stack 
+      !  BRN-VERSION 3 -> include D_stack, V_stack, Ts_stack, building%type 
       !  BRN-VERSION 4 -> free format, include include D_stack, V_stack, Ts_stack, building%length, building%width, building%height, building%orientation
       !*************************************************************************
        idgr=-999
-
+       
        ! Read emission line:
        IF (VsDs_opt) then
           IF (brn_version .GE. 4) THEN
              READ (cbuf, *, IOSTAT = ierr) mm, x, y, qob, qww, hbron, diameter, szopp, D_stack, V_stack, Ts_stack_C, ibtg, ibroncat, iland, idgr,  &
                                            building%length, building%width, building%height, building%orientation
-
+                                           
              ! Building orientation must be between 0 and 180 degrees:
-             if (.not. is_missing (building%orientation)) building%orientation = modulo(building%orientation, 180.0)
-
+             if (.not. is_missing (building%orientation)) building%orientation = modulo(building%orientation, 180.0)  
+             
              ! Set flag if one building is present:
-             if (.not. building_present1) building_present1 = (.not. (is_missing(building%length) .or. is_missing(building%width) .or. is_missing(building%height) .or. is_missing(building%orientation)))
-
+             if (.not. building_present1) building_present1 = (.not. (is_missing(building%length) .or. is_missing(building%width) .or. is_missing(building%height) .or. is_missing(building%orientation))) 
+             
           ELSEIF (brn_version .EQ. 3) THEN
              READ (cbuf, *, IOSTAT = ierr) mm, x, y, qob, qww, hbron, diameter, szopp, D_stack, V_stack, Ts_stack_C, ibtg, ibroncat, iland, idgr, building%type
-
-          ELSE
+             
+          ELSE 
              READ (cbuf, *, IOSTAT = ierr) mm, x, y, qob, qww, hbron, diameter, szopp, D_stack, V_stack, Ts_stack_C, ibtg, ibroncat, iland, idgr
           ENDIF
-
+          
           ! Negative V_stack in input -> horizontal outflow (except V_stack = -999 -> missing value):
           if (V_stack .lt. 0.0 .and. .not. is_missing(V_stack)) then
              V_stack = -V_stack
              emis_horizontal = .TRUE.
           endif
-
+       
        ELSE
           READ (cbuf, *, IOSTAT = ierr) mm, x, y, qob, qww, hbron, diameter, szopp, ibtg, ibroncat, iland, idgr
        ENDIF
        ! write(*,*) 'ops_read_source VsDs_opt = ',VsDs_opt
        ! write(*,'(a,i6,10(1x,e12.5),4(1x,i4),1x,l6)') 'ops_read_source a ',mm, x, y, qob, qww, hbron, diameter, szopp, D_stack, V_stack, Ts_stack_C, ibtg, ibroncat, iland, idgr,emis_horizontal
-       ! write(*,*) 'ops_read_source a, nrec, ierr = ',nrec,ierr
-
+       ! write(*,*) 'ops_read_source a, nrec, ierr = ',nrec,ierr  
+       
        IF (ierr == 0) THEN
-
+        
           ! Convert lon-lat coordinates to RDM coordinates; lon-lat coordinates are detected if the value read for y is less than 90 degrees:
           IF ( abs(y) .LT. 90 ) THEN
             gb = y
@@ -275,45 +271,45 @@ IF (.NOT. end_of_file) THEN
        ENDIF
    ELSE
       !*******************************************************
-      !  Old brn-file, fixed format
+      !  Old brn-file, fixed format 
       !  Reading of D_stack, V_stack, Ts_stack not supported.
       !*******************************************************
       ! In the old format, if there is a dot at position 9, coordinates are assumed to be lon-lat
       IF ( cbuf(9:9) .EQ. '.' ) THEN
-
-         ! Read source record with lon-lat coordinates (gl,gb)
+    
+         ! Read source record with lon-lat coordinates (gl,gb) 
          ! "g" << geographical coordinates; "l" << lengtegraad = longitude, "b" << breedtegraad = latitude
          READ (cbuf, 100, IOSTAT = ierr) mm, gl, gb, qob, qww, hbron, diameter, szopp, ibtg, ibroncat, iland, idgr
 
          IF (ierr == 0) THEN
-
+   
             ! Convert lon-lat coordinates to RDM coordinates
             CALL geo2amc(gb, gl, x, y) ! (x,y) in km
             x = AINT(x*1000.) ! [m]
             y = AINT(y*1000.) ! [m]
          ENDIF
       ELSE
-
+      
          ! Read source record with RDM coordinates:
          READ (cbuf, 150, IOSTAT = ierr) mm, x, y, qob, qww, hbron, diameter, szopp, ibtg, ibroncat, iland, idgr
       ENDIF
    ENDIF ! IF (brn_version .GE. 1)
 
-   ! Current emission record has been read and coordinates have been converted to RDM;
+   ! Current emission record has been read and coordinates have been converted to RDM; 
    ! add  1 to record number (unless ierr < 0 = end-of-file):
-   IF (ierr .GE. 0 ) nrec = nrec + 1
-   ! write(*,*) 'nrec, ierr = ',nrec,ierr
-   ! write(*,'(a,a)') 'cbuf: ',trim(cbuf)
-
+   IF (ierr .GE. 0 ) nrec = nrec + 1 
+   ! write(*,*) 'nrec, ierr = ',nrec,ierr 
+   ! write(*,'(a,a)') 'cbuf: ',trim(cbuf) 
+   
    IF (ierr == 0) THEN
-
+     
       ! Check emission strength, heat content, emission height and diameter area source.
-      ! Note: check is only performed inside check_source2 if no error has occurred;
+      ! Note: check is only performed inside check_source2 if no error has occurred; 
       !       therefore there is no need to check for error%haserror here each time.
-      ! JA*  check is only needed if source is selected.
-      !
-
-      ! Check range for
+      ! JA*  check is only needed if source is selected. 
+      ! 
+    
+      ! Check range for 
       !    deviation                     : 0 <= szopp <= hbron
       !    diurnal variation             : -999 <= ibtg <= 999
       !    emission category             : 1 <= ibroncat <= 9999
@@ -322,7 +318,7 @@ IF (.NOT. end_of_file) THEN
       if (brn_version .lt. 2) then
          ! Adjust value within range and continue OPS; write warning to log-file (backward compatibility for old emission files):
          CALL check_source (nrec, '<emission strength [g/s]>', 0., 99999., qob, error)
-         if (.not. is_missing(qww)) CALL check_source(nrec, '<heat content [MW]>', 0., 999., qww, error)
+         if (.not. is_missing(qww)) CALL check_source(nrec, '<heat content [MW]>', 0., 999., qww, error) 
          CALL check_source (nrec, '<emission height [m]>', 0., 5000.0, hbron, error)
          CALL check_source (nrec, '<diameter area source [m]>',-999999., 999999., diameter, error)
          CALL check_source (nrec, '<deviatie>', 0., hbron, szopp, error)
@@ -334,7 +330,7 @@ IF (.NOT. end_of_file) THEN
       else
          ! Generate error and stop OPS:
          CALL check_source2('<emission strength [g/s]>', 0., 99999., qob, error)
-         if (.not. is_missing(qww)) CALL check_source2('<heat content [MW]>', 0., 999., qww, error)
+         if (.not. is_missing(qww)) CALL check_source2('<heat content [MW]>', 0., 999., qww, error) 
          ! CALL check_source2('<emission height [m]>', 0., HUMAX, hbron, error)
          CALL check_source2('<emission height [m]>', 0., 5000.0, hbron, error)
          CALL check_source2('<diameter area source [m]>',-999999., 999999., diameter, error)
@@ -343,7 +339,7 @@ IF (.NOT. end_of_file) THEN
          CALL check_isource2('<categorie>', 1, 9999, ibroncat, error)
          CALL check_isource2('<land>', 1, 9999, iland, error)
          CALL check_isource2('<verdeling>', -999, MAXDISTR, idgr, error)
-
+        
          ! Check stack parameters:
          call check_stack_param(qww, VsDs_opt, D_stack, V_stack, Ts_stack_C, error)
 
@@ -357,26 +353,26 @@ IF (.NOT. end_of_file) THEN
             call check_building_param(building, hbron, qww, D_stack, V_stack, error)
          endif
       endif
-
+   
       if (VsDs_opt) then
          ! Convert Ts_stack to K:
          if (is_missing(Ts_stack_C)) then
             Ts_stack = Ts_stack_C
          else
-            Ts_stack = Ts_stack_C + T0
+            Ts_stack = Ts_stack_C + T0   
          endif
       endif
-
+    
       ! Check whether ibtg and idgr distributions in this record have been read (using presentcode array).
       ! Check whether ibtg is not for NH3 (icm=3) and NOx (icm=2) if a special diurnal variation (4 or 5) is used.
-      ! Check whether particle size distribution has been read.
+      ! Check whether particle size distribution has been read.       
       IF (.NOT.((icm == 2 .OR. icm == 3) .AND. (ibtg == 4 .OR. ibtg == 5)))  THEN
           CALL check_verdeling(ibtg, presentcode, 1, 3, 'ibtg', error)
       ENDIF
-      IF (check_psd) THEN
+      IF (check_psd) THEN                                                     
         CALL check_verdeling(idgr, presentcode, 2, 4, 'idgr', error)
       ENDIF
-      IF (error%haserror) GOTO 9999
+      IF (error%haserror) GOTO 9999    
 
    ELSE
 
@@ -400,7 +396,7 @@ END SUBROUTINE ops_emis_read_annual1
 ! SUBROUTINE NAME    : check_source
 ! DESCRIPTION        : check whether a source parameter lies within a specified range. If not, the paramater is fixed at either
 !                      the lower or upper limit of the range. In this case, a warning is written to the log file;
-!                      this warning includes the record number of the source.
+!                      this warning includes the record number of the source. 
 !                      Included for backward compatibility of old source files; better use check_source2.
 ! CALLED FUNCTIONS   :
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -411,7 +407,7 @@ USE m_commonfile, only: fu_log
 USE m_commonconst, only: EPS_DELTA
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM               
 PARAMETER    (ROUTINENAAM = 'check_source')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -496,7 +492,7 @@ END SUBROUTINE check_source
 ! SUBROUTINE NAME    : check_isource
 ! DESCRIPTION        : check whether an integer source parameter lies within a specified range. If not, the paramater is fixed at either
 !                      the lower or upper limit of the range. In this case, a warning is written to the log file;
-!                      this warning includes the record number of the source.
+!                      this warning includes the record number of the source. 
 !                      Included for backward compatibility of old source files; better use check_isource2.
 ! CALLED FUNCTIONS   :
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -505,7 +501,7 @@ SUBROUTINE check_isource(nr, varnaam, onder, boven, varwaarde, error)
 USE m_error
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                
 PARAMETER    (ROUTINENAAM = 'check_source')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -519,7 +515,7 @@ INTEGER*4, INTENT(INOUT)                         :: varwaarde                  !
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 ! LOCAL VARIABLES
-REAL*4                                           :: var                        ! help variable (= float(varwaarde))
+REAL*4                                           :: var                        ! help variable (= float(varwaarde)) 
 
 var = FLOAT(varwaarde)
 CALL check_source(nr, varnaam, FLOAT(onder), FLOAT(boven), var, error)
@@ -540,7 +536,7 @@ USE m_error
 USE m_commonconst, only: EPS_DELTA
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM               
 PARAMETER    (ROUTINENAAM = 'check_source2')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -587,7 +583,7 @@ USE m_commonconst, only: EPS_DELTA
 USE m_commonfile, only: fu_log
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM               
 PARAMETER    (ROUTINENAAM = 'check_source3')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -612,10 +608,10 @@ IF (varwaarde .LT. (onder - EPS_DELTA) .OR. varwaarde .GT. (boven + EPS_DELTA)) 
     CALL ErrorParam(trim(varnaam), varwaarde, error)
     CALL ErrorParam('upper limit', boven, error)
     CALL ErrorCall(ROUTINENAAM, error)
-
+    
    ! Reset error message (only warning):
    error%haserror = .FALSE.
-
+   
    ! Write warning to log file:
    CALL WriteError(fu_log, error)
 
@@ -637,7 +633,7 @@ SUBROUTINE check_isource2(varnaam, onder, boven, varwaarde, error)
 USE m_error
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                
 PARAMETER    (ROUTINENAAM = 'check_source2')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -666,15 +662,15 @@ USE m_error
 USE m_commonconst, only: MAXDISTR
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                
 PARAMETER    (ROUTINENAAM = 'check_verdeling')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-INTEGER*4, INTENT(IN)                            :: icode                      ! code that has to be checked;
+INTEGER*4, INTENT(IN)                            :: icode                      ! code that has to be checked; 
                                                                                ! if icode < 0 -> check whether a user defined distribution is present
                                                                                ! if icode > 0 -> check whether a standard distribution is present
                                                                                ! if icode = 0 -> do not check anything
-LOGICAL,   INTENT(IN)                            :: presentcode(MAXDISTR,4)
+LOGICAL,   INTENT(IN)                            :: presentcode(MAXDISTR,4)     
 INTEGER*4, INTENT(IN)                            :: stdclass                   ! index of standard distributions in 2nd dimension of presentcode
 INTEGER*4, INTENT(IN)                            :: usdclass                   ! index of user defined distributions in 2nd dimension of presentcode
 CHARACTER*(*), INTENT(IN)                        :: parname                    ! parameter name in error messages
@@ -722,7 +718,7 @@ USE m_ops_utils, only: is_missing
 USE m_commonconst, only: EPS_DELTA
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                
 PARAMETER    (ROUTINENAAM = 'check_stack_param')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -749,14 +745,14 @@ else
   if (is_missing(qww)) then
       CALL SetError('Heat content (Qw) must be specified', error)
       CALL ErrorParam('Qw', qww, error)
-      CALL ErrorCall(ROUTINENAAM, error)
+      CALL ErrorCall(ROUTINENAAM, error)  
    endif
 endif
 
 ! Check ranges:
 ! (for the check on Ts_stack_C -> see also check in m_ops_plume_rise - ops_plumerise_qw_Ts)
 if (.not. is_missing(D_stack))    CALL check_source2('<inner diameter stack [m]>'      , 0.01 ,   30.0 , D_stack, error)       ! Infomil NNM 2.1.2 - Modelinvoer
-if (.not. is_missing(V_stack))    CALL check_source2('<exit velocity [m/s]>'           , 0.0  ,   50.0 , V_stack, error)       ! V_stack = 0 is ok; in this case Qw = 0. Upper limit V_stack?
+if (.not. is_missing(V_stack))    CALL check_source2('<exit velocity [m/s]>'           , 0.0  ,   50.0 , V_stack, error)       ! V_stack = 0 is ok; in this case Qw = 0. Upper limit V_stack? 
 if (.not. is_missing(Ts_stack_C)) CALL check_source2('<temperature effluent gas [C]>'  , 0.0  , 2000.0 , Ts_stack_C, error)    ! temperature waste burning ~ 1300 C
 
 ! Check whether V_stack = 0 and Qw > 0 -> error
@@ -765,7 +761,7 @@ if (.not. is_missing(V_stack)) then
       CALL SetError('If exit velocity (V_stack) is zero, then heat content (Qw) must be zero also.','Use V_stack = -999. if you only want to specify Qw.', error)
       CALL ErrorParam('V_stack', V_stack, error)
       CALL ErrorParam('Qw', qww, error)
-      CALL ErrorCall(ROUTINENAAM, error)
+      CALL ErrorCall(ROUTINENAAM, error)  
    endif
 endif
 
@@ -773,7 +769,7 @@ END SUBROUTINE check_stack_param
 
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE NAME    : check_building_param
-! DESCRIPTION        : Check building parameters
+! DESCRIPTION        : Check building parameters 
 ! CALLED FUNCTIONS   :
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE check_building_param(building, hbron, qww, D_stack, V_stack, error)
@@ -785,7 +781,7 @@ use m_ops_building
 USE m_commonfile, only: fu_log
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM
+CHARACTER*512                                    :: ROUTINENAAM                
 PARAMETER    (ROUTINENAAM = 'check_building_param')
 
 ! Input:
@@ -806,27 +802,27 @@ if (.not. (is_missing(building%length) .or. is_missing(building%width) .or. is_m
 
    ! Set width/length ratio:
    if (building%length > 0.0) then
-      wlRatio = building%width/building%length
+      wlRatio = building%width/building%length  
    else
       ! if length = 0 -> buildingType = 0 (see below)
       wlRatio = HUGE(1.0)
    endif
-
-   ! If values outside limits -> warning
-   ! limits based on data for 2500 animal houses in 2018
+   
+   ! If values outside limits -> warning   
+   ! limits based on data for 2500 animal houses in 2018  
    ! Note that it is already checked that all building dimensions (length, width, height) have been specified
 
-   ! Open log file if not already open:
+   ! Open log file if not already open:   
    call ops_openlog(error)
    if (error%haserror) goto 9999
-
+   
    ! Error if Qw must be specified (= 0) and cannot be missing:
    if (is_missing(qww)) then
       CALL SetError('If building is present, then heat content (Qw) must be zero (cannot be missing).', error)
       CALL ErrorParam('Qw', qww, error)
-      goto 9999
+      goto 9999  
    endif
-
+   
    ! Warnings if value is outside table boundaries:
                                              CALL check_source3('check table building effect ','<building height [m]>'             ,  0.0  ,  20.0  , building%height, error)
    if (.not. is_missing(hbron))              CALL check_source3('check table building effect ','<emission height [m]>'             ,  0.0  ,  20.0  , hbron, error)
@@ -836,9 +832,9 @@ if (.not. (is_missing(building%length) .or. is_missing(building%width) .or. is_m
                                              CALL check_source3('check table building effect ','<width/length ratio building [-]>' ,  0.15 ,   1.0 , wlRatio, error)
                                              CALL check_source3('check table building effect ','<building length [m]>'             , 10.0  , 105.0  , building%length, error)
                                              CALL check_source3('check table building effect ','<building orientation [degrees w.r.t. x-axis]>' , 0.0  , 180.0  , building%orientation, error)
-
+   
 endif
-
+   
 RETURN
 
 9999 CALL ErrorCall(ROUTINENAAM, error)

--- a/m_ops_emis.f90
+++ b/m_ops_emis.f90
@@ -515,7 +515,7 @@ INTEGER*4, INTENT(INOUT)                         :: varwaarde                  !
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 ! LOCAL VARIABLES
-REAL*4                                           :: var                        ! help variable (= float(varwaarde)) 
+real                                             :: var                        ! help variable (= float(varwaarde))
 
 var = FLOAT(varwaarde)
 CALL check_source(nr, varnaam, FLOAT(onder), FLOAT(boven), var, error)

--- a/m_ops_plumerise.f90
+++ b/m_ops_plumerise.f90
@@ -1,26 +1,22 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
-!-------------------------------------------------------------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 module m_ops_plumerise
 
 ! module m_ops_plumerise with plume rise due to either buoyancy or momentum
-! Marina Sterk and Ferd Sauter 2018-02-20
+! Marina Sterk and   2018-02-20
 
 ! ops_plumerise             : main routine containing the calls to different parts of the final plume rise, and the calculation of the final plume rise
 ! ops_plumerise_buoyancy    : determine plume rise due to buoyancy
@@ -31,7 +27,7 @@ implicit none
 
 ! T0   = reference temperature = 273.15 K = 0 C
 ! P0   = reference pressure = 1 atm = 101.325 kPa
-real, parameter :: rho0 = 1.293 ! reference density air at pressure P0, temperature T0 (= 1.293 kg/m3)
+real, parameter :: rho0 = 1.293 ! reference density air at pressure P0, temperature T0 (= 1.293 kg/m3) 
 real, parameter :: Cp0  = 1005  ! reference specific heat of air at pressure P0, temperature T0 (= 1005 J/kg/K)
 
 contains
@@ -40,11 +36,11 @@ contains
 subroutine ops_plumerise_prelim(istab, isek, astat, hemis0, qw, D_stack, V_stack, Ts_stack, emis_horizontal, hemis1, error)
 
 ! Compute preliminary plume rise, based on stability class and preliminary wind sector (ol, uster, ... still unknown)
-
+ 
 use m_commonconst, only: NTRAJ, NCOMP, NSTAB, NSEK
 use m_ops_utils, only: is_missing
 use m_error
-
+ 
 ! Input:
 integer, intent(in) :: istab             ! index of stability class and preliminary wind sector
 integer, intent(in) :: isek              ! index of preliminary wind sector (wind shear not yet taken into account)
@@ -58,12 +54,12 @@ logical, intent(in) :: emis_horizontal   ! horizontal outflow of emission
 
 ! Output:
 real, intent(out)          :: hemis1     ! emission height, including plume rise [m]
-type (TError), intent(out) :: error      ! error handling record
+type (TError), intent(out) :: error      ! error handling record 
 
 ! Local:
 logical :: prelim              ! preliminary plume rise, based on stability class and preliminary wind sector (ol, uster, ... still unknown)
-                               ! if prelim = true  -> ol = -999, uster = -999, z0 = -999, zmix = zmix_loc = -999
-                               !                      these parameters are still unknown;
+                               ! if prelim = true  -> ol = -999, uster = -999, z0 = -999, zmix = zmix_loc = -999 
+                               !                      these parameters are still unknown; 
                                !                      wind profile is based on power law with coefficient based on stability class
 logical :: VsDs_opt            ! include exit velocity (Vs = V_stack), stack diameter (Ds = D_stack) and effluent temperature (Ts_stack) in the emission file
 real    :: dum                 ! dummy output of ops_plumerise
@@ -74,16 +70,16 @@ character(len = 80), parameter :: ROUTINENAAM = 'ops_plumerise_prelim'
 prelim   = .true.
 VsDs_opt = .not. is_missing(V_stack)
 temp_C   = 12.0  ! default average value (is not a sensitive parameter for preliminary estimate)
-call ops_plumerise(-999., hemis0, -999., -999., qw, VsDs_opt, D_stack, V_stack, Ts_stack, emis_horizontal, temp_C, -999., -999., &
+call ops_plumerise(-999., hemis0, -999., -999., qw, VsDs_opt, D_stack, V_stack, Ts_stack, emis_horizontal, temp_C, -999., -999., &  
                    hemis1, dum, error, prelim, istab, isek, astat)
 ! write(*,'(a,4(1x,e12.5))') 'in routine ops_plumerise_prelim a: ',hemis0,hemis1,hemis1-hemis0,-999.0
 
-if (error%haserror) call ErrorCall(ROUTINENAAM, error)
-
+if (error%haserror) call ErrorCall(ROUTINENAAM, error) 
+                                     
 end subroutine ops_plumerise_prelim
 
 !------------------------------------------------------------
-subroutine ops_plumerise(z0, hemis0, uster, ol, qw, VsDs_opt, D_stack, V_stack, Ts_stack, emis_horizontal, temp_C, zmix, zmix_loc, &
+subroutine ops_plumerise(z0, hemis0, uster, ol, qw, VsDs_opt, D_stack, V_stack, Ts_stack, emis_horizontal, temp_C, zmix, zmix_loc, & 
                          hemis1, onder, error, prelim, istab, isek, astat)
 
 ! Main routine for the different plume rise calculations
@@ -103,27 +99,27 @@ real,    intent(in) :: D_stack           ! diameter of the stack [m]
 real,    intent(in) :: V_stack           ! exit velocity of plume at stack tip [m/s]
 real,    intent(in) :: Ts_stack          ! temperature of effluent from stack [K]
 logical, intent(in) :: emis_horizontal   ! horizontal outflow of emission
-real,    intent(in) :: temp_C            ! ambient temperature at height zmet_T [C]
-real,    intent(in) :: zmix              ! mixing height [m]
+real,    intent(in) :: temp_C            ! ambient temperature at height zmet_T [C] 
+real,    intent(in) :: zmix              ! mixing height [m] 
 real,    intent(in) :: zmix_loc          ! mixing height, local scale [m]
 
-! Output
+! Output                              
 real, intent(out)   :: hemis1            ! emission height, including plume rise [m]
-real, intent(out)   :: onder             ! part of plume below mixing height
-type (TError), intent(out) :: error      ! error handling record
+real, intent(out)   :: onder             ! part of plume below mixing height 
+type (TError), intent(out) :: error      ! error handling record 
 
 ! Input, optional:
 logical, intent(in), optional :: prelim  ! preliminary plume rise, based on stability class and preliminary wind sector (ol, uster, ... still unknown)
-                                         ! if prelim = true  -> ol = -999, uster = -999, z0 = -999, zmix = zmix_loc = -999
-                                         !                      these parameters are still unknown;
+                                         ! if prelim = true  -> ol = -999, uster = -999, z0 = -999, zmix = zmix_loc = -999 
+                                         !                      these parameters are still unknown; 
                                          !                      wind profile is based on power law with coefficient based on stability class
                                          ! if prelim = false or not present -> istab, isek are not used
-                                         !                      wind profile is computed with ops_wvprofile (logarithmic profile) using z0, ol, uster
+                                         !                      wind profile is computed with ops_wvprofile (logarithmic profile) using z0, ol, uster 
 integer, intent(in), optional :: istab   ! index of stability class and preliminary wind sector
 integer, intent(in), optional :: isek    ! index of preliminary wind sector (wind shear not yet taken into account)
 real   , intent(in), optional :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! statistical meteo parameters
-
-! Local
+                                        
+! Local                                 
 real                :: u_stack           ! wind speed at stack height [m/s]
 real                :: u_threshold       ! threshold wind speed at height z_u_threshold [m/s]
 real                :: dh_buoyancy       ! plume rise due to buoyancy [m]
@@ -151,37 +147,37 @@ endif
 
 ! write(*,'(a,4(1x,e12.5))') 'in routine ops_plumerise a: ',hemis0,hemis1,hemis1-hemis0,-999.0
 
-! Set fixed potential temperature gradient dtheta/dz for stable conditions.
+! Set fixed potential temperature gradient dtheta/dz for stable conditions. 
 ! In the OPS manual (just below Eq. 4.6) it is stated that an average value of 0.006 K/m is taken as representative
-! for stable situations, following TNO (1976).
-! TNO (1976) Modellen voor de berekening van de verspreiding van luchtverontreiniging inclusief aanbevelingen voor de waarden van
+! for stable situations, following TNO (1976). 
+! TNO (1976) Modellen voor de berekening van de verspreiding van luchtverontreiniging inclusief aanbevelingen voor de waarden van 
 ! parameters in het lange-termijnmodel. Staatsuitgeverij, The Hague, the Netherlands.
-! Just above Eq. 4.3 of the OPS manual it is stated that this is the reference to the Dutch National Model.
-! However, in the manual of the NNM (March 2002), 0.006 is not used, but the profile is reviewed per 10m layer.
-! For stable conditions a dtheta/dz of at least 0.005 K/m is applied.
+! Just above Eq. 4.3 of the OPS manual it is stated that this is the reference to the Dutch National Model. 
+! However, in the manual of the NNM (March 2002), 0.006 is not used, but the profile is reviewed per 10m layer. 
+! For stable conditions a dtheta/dz of at least 0.005 K/m is applied. 
 ! MS Possibly better to calculate dtheta/dz per layer as well? Also due to changing stability with height which affects plume rise?
-dthetadz_stable = 0.006
+dthetadz_stable = 0.006   
 
-! Obtain temperature at stack height.
-! Use theta(z) = T(z) + Tau*z   (Tau = 9.8*10^-3 K/m = dry adiabatic lapse rate = g/Cp) (Stull 2000, Meteorology for Scientists and Engineers, Second Edition).
+! Obtain temperature at stack height. 
+! Use theta(z) = T(z) + Tau*z   (Tau = 9.8*10^-3 K/m = dry adiabatic lapse rate = g/Cp) (Stull 2000, Meteorology for Scientists and Engineers, Second Edition). 
 !
 !              T(z2) - T(z1) + Tau*(z2-z1)
-! dtheta/dz = ---------------------------    -->   T(z2) = dtheta/dz * (z2-z1) - Tau*(z2-z1) + T(z1);
+! dtheta/dz = ---------------------------    -->   T(z2) = dtheta/dz * (z2-z1) - Tau*(z2-z1) + T(z1);   
 !                      z2 - z1
 ! T(z1) is the temperature at z1, taken as the temperature from the meteo-file at zmet_T = 1.5m height.
 Ta_stack = dthetadz_stable*(hemis0-zmet_T) - (9.8e-3)*(hemis0-zmet_T) + (temp_C + T0)
 
 ! Check for non-stable (unstable/neutral) conditions:
 if (prelim1) then
-   non_stable =  ( istab .lt. 5 )
+   non_stable =  ( istab .lt. 5 ) 
 else
-   non_stable =  ( ol .lt. (0. - EPS_DELTA) .or. abs(ol) .gt. 50 )
+   non_stable =  ( ol .lt. (0. - EPS_DELTA) .or. abs(ol) .gt. 50 ) 
 endif
 
 ! 1. Compute effluent temperature Ts_stack or heat content Qw depending on input specified;
 !    Ts missing -> compute Qw, Qw missing -> compute Ts:
 call ops_plumerise_qw_Ts(VsDs_opt, qw, D_stack, V_stack, Ts_stack, emis_horizontal, Ta_stack, qw2, Ts_stack2, error)
-if (error%haserror) goto 9999
+if (error%haserror) goto 9999 
 
 ! 2. Compute wind speed at stack height:
 if (prelim1) then
@@ -192,17 +188,17 @@ endif
 
 ! 3. Determine plume rise due to buoyancy. This is including iterations to resolve the interdependency between plume rise and wind speed
 if (present(prelim)) then
-   call ops_plumerise_buoyancy(z0,ol,uster,non_stable,qw2,Ta_stack,dthetadz_stable,u_stack,hemis0,dh_buoyancy,prelim,istab,isek,astat)
+   call ops_plumerise_buoyancy(z0,ol,uster,non_stable,qw2,Ta_stack,dthetadz_stable,u_stack,hemis0,dh_buoyancy,prelim,istab,isek,astat) 
 else
-   call ops_plumerise_buoyancy(z0,ol,uster,non_stable,qw2,Ta_stack,dthetadz_stable,u_stack,hemis0,dh_buoyancy)
+   call ops_plumerise_buoyancy(z0,ol,uster,non_stable,qw2,Ta_stack,dthetadz_stable,u_stack,hemis0,dh_buoyancy) 
 endif
 
 ! write(*,'(a,4(1x,e12.5))') 'in routine ops_plumerise b: ',hemis0,hemis1,hemis1-hemis0,-999.0
 
 ! 4. Determine plume rise due to momentum (no momentum plume rise in case of horizontal emission):
 if (VsDs_opt .and. .not. emis_horizontal) then
-
-    ! Low stack with low wind velocity may lead to large oversestimation of plume rise ->
+      
+    ! Low stack with low wind velocity may lead to large oversestimation of plume rise -> 
     ! 10 m is used as threshold for wind speed calculation (personal communication Hans Erbrink):
     if (hemis0 .lt. z_u_threshold) then
        if (prelim1) then
@@ -214,14 +210,14 @@ if (VsDs_opt .and. .not. emis_horizontal) then
     else
        call ops_plumerise_momentum(u_stack,D_stack,V_stack,Ts_stack2,Ta_stack,dthetadz_stable,non_stable,dh_momentum)
     endif
-else
+else 
     dh_momentum = 0.0
 endif
 ! write(*,'(a,4(1x,e12.5))') 'in routine ops_plumerise : ',dh_buoyancy,dh_momentum
 
 ! 5. Compare plume rise due to buoyancy and momentum, which process is dominant? Adopt that plume rise.
-! If buoyancy plume rise is greater than momentum plume rise, discard momentum plume rise,
-! because in the parameterisation of buoyancy plume rise, momentum plume rise has been taken into account (see NNM Paarse boekje):
+! If buoyancy plume rise is greater than momentum plume rise, discard momentum plume rise,   
+! because in the parameterisation of buoyancy plume rise, momentum plume rise has been taken into account (see NNM Paarse boekje): 
 if (dh_buoyancy .ge. dh_momentum) then
     dh = dh_buoyancy
 else
@@ -231,12 +227,12 @@ hemis1 = hemis0 + dh
 ! write(*,'(a,4(1x,e12.5))') 'in routine ops_plumerise c: ',hemis0,hemis1,hemis1-hemis0,-999.0
 
 ! 6. plume penetration
-if (.not. prelim1) call ops_plume_penetration(hemis0,zmix,zmix_loc,ol,dh,hemis1,onder)
+if (.not. prelim1) call ops_plume_penetration(hemis0,zmix,zmix_loc,ol,dh,hemis1,onder) 
 ! write(*,'(a,4(1x,e12.5))') 'in routine ops_plumerise d: ',hemis0,hemis1,hemis1-hemis0,-999.0
 
 return
 
-9999 call ErrorCall(ROUTINENAAM, error)
+9999 call ErrorCall(ROUTINENAAM, error) 
 
 end subroutine ops_plumerise
 
@@ -244,7 +240,7 @@ end subroutine ops_plumerise
 subroutine ops_plumerise_qw_Ts(VsDs_opt, qw, D_stack, V_stack, Ts_stack, emis_horizontal, Ta_stack, qw2, Ts_stack2, error)
 
 ! Compute effluent temperature Ts_stack or heat content Qw depending on input specified;
-! Ts_stack missing -> compute Qw, Qw missing -> compute Ts_stack. Note that is has been checked already that either one of them is missing.
+! Ts_stack missing -> compute Qw, Qw missing -> compute Ts_stack. Note that is has been checked already that either one of them is missing. 
 !
 
 use Binas, only: T0, pi                  ! melting point of ice [K], pi
@@ -258,41 +254,41 @@ real,    intent(in) :: D_stack            ! diameter of the stack [m]
 real,    intent(in) :: V_stack            ! exit velocity of plume at stack tip [m/s]
 real,    intent(in) :: Ts_stack           ! temperature of effluent from stack [K]
 logical, intent(in) :: emis_horizontal    ! horizontal outflow of emission
-real,    intent(in) :: Ta_stack           ! ambient temperature at stack height (K)
+real,    intent(in) :: Ta_stack           ! ambient temperature at stack height (K) 
 
 ! Output:
 real,    intent(out) :: Ts_stack2         ! effluent temperature at stack height, but missing value replaced by computation from Qw [K]
 real,    intent(out) :: qw2               ! heat content emission, but missing value replaced by computation from Ts [MW]
-type (TError), intent(out) :: error       ! error handling record
+type (TError), intent(out) :: error       ! error handling record 
 
-!Local:
-real                 :: C1                ! help variable = rho0*Cp0*(pi*(0.5*D_stack)**2)*V_stack*T0*(1.0e-6). Needed for Ts_stack2
+!Local: 
+real                 :: C1                ! help variable = rho0*Cp0*(pi*(0.5*D_stack)**2)*V_stack*T0*(1.0e-6). Needed for Ts_stack2 
 real                 :: V0                ! normal volume flux [m0**3/s)
 
 character(len = 80), parameter :: ROUTINENAAM = 'ops_plumerise_qw_Ts'
 
-! qw = rho0*Cp0*V0*(Ts - Ta)*1e-6 or 1e6*qw/(rho0*Cp0*V0) = Ts - Ta <=> Ts = Ta + 1e6*qw/(rho0*Cp0*V0)
+! qw = rho0*Cp0*V0*(Ts - Ta)*1e-6 or 1e6*qw/(rho0*Cp0*V0) = Ts - Ta <=> Ts = Ta + 1e6*qw/(rho0*Cp0*V0)   
 ! T0   = reference temperature = 273.15 K = 0 C
 ! P0   = reference pressure = 1 atm = 101.325 kPa
 ! rho0 = reference density air (= 1.293 kg/m3) at pressure P0, temperature T0
 ! Cp0  = reference specific heat of air at pressure P0, temperature T0 (= 1005 J/kg/K)
-! V0   = normal volume flux (m03/s) at pressure P0, temperature T0
-! Ts   = effluent temperature (K)
-! Ta   = ambient temperature at stack height (K)
+! V0   = normal volume flux (m03/s) at pressure P0, temperature T0  
+! Ts   = effluent temperature (K) 
+! Ta   = ambient temperature at stack height (K) 
 
 ! write(*,*) 'ops_plumerise_qw_Ts a:',VsDs_opt,qw,Ts_stack
 if (VsDs_opt) then
    if (is_missing(Ts_stack)) then
-
+   
       !----------------------------------------------------------------
       ! Heat content qw given, compute effluent temperature Ts_stack2
       !----------------------------------------------------------------
-
+      
       if (emis_horizontal) then
          Ts_stack2 = -999.0
       else
          if (qw .eq. 0.0) then
-            Ts_stack2 = Ta_stack
+            Ts_stack2 = Ta_stack   
          else
          ! Compute effluent temperature (not needed in case of horizontal outflow):
             ! Ts = Ta + 1e6*qw/(rho0*Cp0*V0)                 (1)
@@ -300,7 +296,7 @@ if (VsDs_opt) then
             ! Substitute (2) in (1) gives Ts = Ta + f Ts <=> Ts = Ta/(1-f), with f = 1e6*qw/(rho0*Cp0*(pi*(0.5*D_stack)**2)*V_stack*T0):
             C1 = rho0*Cp0*(pi*(0.5*D_stack)**2)*V_stack*T0*(1.0e-6)
             Ts_stack2 = Ta_stack/(1.0 - qw/C1)
-
+            
             ! Check:
             ! This check is not needed; next check is more stringent:
             ! if (qw .ge. C1) then
@@ -317,20 +313,20 @@ if (VsDs_opt) then
                call ErrorParam('lower limit effluent gas temperature [C]',0.0,error)
                call ErrorParam('<effluent gas temperature [C]>',Ts_stack2-T0,error)
                call ErrorParam('upper limit effluent gas temperature [C]',2000.0,error)
-               call ErrorCall(ROUTINENAAM, error)
+               call ErrorCall(ROUTINENAAM, error) 
             endif
          endif   ! if qw = 0
-      endif   ! if emis_horizontal
+      endif   ! if emis_horizontal 
       qw2 = qw
    else
 
       !------------------------------------------------
       ! Ts_stack is given; compute heat content qw2
       !------------------------------------------------
-
+   
       ! Compute normal volume flux, according to ideal gas-law (at constant pressure): V0_flux/T0 = Vs_flux/Ts, Vs_flux = pi R**2 Vs_stack
-      V0 = (pi*(0.5*D_stack)**2)*V_stack*T0/Ts_stack
-
+      V0 = (pi*(0.5*D_stack)**2)*V_stack*T0/Ts_stack  
+   
       ! Compute qw:
       Ts_stack2 = Ts_stack
       qw2 = rho0*Cp0*V0*(Ts_stack - Ta_stack)*1e-6
@@ -347,11 +343,11 @@ end subroutine ops_plumerise_qw_Ts
 !------------------------------------------------------------
 subroutine ops_plumerise_buoyancy(z0, ol, uster, non_stable, qw, Ta_stack, dthetadz_stable, u_stack, hemis0, dh_buoyancy, prelim, istab, isek, astat)
 !-------------------------------------------------------------------------------------------------------------------------------
-!
-! DESCRIPTION: This routine calculates the plume rise due to buoyancy.
+! 
+! DESCRIPTION: This routine calculates the plume rise due to buoyancy. 
 !    This routine includes plume rise formulations given by Briggs(1969) and Briggs(1971).
 !    This method is equal to the method used in the (old) Dutch National Model (TNO, 1976).
-!                                                HvJ 960121
+!                                                  960121
 !    Extra iteration, because wind speed depends on plume height and vice versa.
 !
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -360,31 +356,31 @@ use m_commonconst, only: pi, NTRAJ, NCOMP, NSTAB, NSEK, EPS_DELTA
 use Binas, only: grav, T0              ! acceleration of gravity [m/s2], melting point of ice [K]
 
 ! Input
-real, intent(in)   :: z0               ! roughness length [m]
+real, intent(in)   :: z0               ! roughness length [m] 
 real, intent(in)   :: ol               ! Monin-Obukhovlengte [m]
-real, intent(in)   :: uster            ! friction velocity [m/s]
+real, intent(in)   :: uster            ! friction velocity [m/s] 
 logical, intent(in):: non_stable       ! non-stable (unstable/neutral) conditions
 real, intent(in)   :: qw               ! heat content (MW)
 real, intent(in)   :: Ta_stack         ! ambient temperature at stack height [K]
 real, intent(in)   :: dthetadz_stable  ! fixed potential temperature gradient dtheta/dz [K/m] for stable conditions, used for dh_buoyancy and dh_momentum
 real, intent(in)   :: u_stack          ! wind speed at stack height [m/s]
-real, intent(in)   :: hemis0           ! initial emission height = stack height [m]
+real, intent(in)   :: hemis0           ! initial emission height = stack height [m]   
 
-! Output
+! Output                           
 real, intent(out)  :: dh_buoyancy      ! plume rise due to buoyancy [m]
 
 ! Input, optional:
 logical, intent(in), optional :: prelim  ! preliminary plume rise, based on stability class and preliminary wind sector (ol, uster, ... still unknown)
-                                         ! if prelim = true  -> ol = -999, uster = -999, z0 = -999, zmix = zmix_loc = -999
-                                         !                      these parameters are still unknown;
+                                         ! if prelim = true  -> ol = -999, uster = -999, z0 = -999, zmix = zmix_loc = -999 
+                                         !                      these parameters are still unknown; 
                                          !                      wind profile is based on power law with coefficient based on stability class
                                          ! if prelim = false or not present -> istab, isek are not used
-                                         !                      wind profile is computed with ops_wvprofile (logarithmic profile) using z0, ol, uster
+                                         !                      wind profile is computed with ops_wvprofile (logarithmic profile) using z0, ol, uster 
 integer, intent(in), optional :: istab   ! index of stability class and preliminary wind sector
 integer, intent(in), optional :: isek    ! index of preliminary wind sector (wind shear not yet taken into account)
 real   , intent(in), optional :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! statistical meteo parameters
-
-! Local
+                                       
+! Local                            
 real               :: f                ! stack buoyancy flux [m^4/s^3]
 real               :: u_plume          ! wind speed at effective plume height, representative for the whole plume rise length [m/s]
 real               :: dtdz             ! potential temperature gradient [K/m]
@@ -392,17 +388,17 @@ real               :: s                ! stability parameter [s^-2]
 logical            :: prelim1          ! = prelim if present, otherwise false
 real               :: vw10             ! wind velocity at 10 m heigth [m/s]
 real               :: pcoef            ! coefficient in wind speed power law
-character(len=1)   :: char_debug1      ! debug character (test only)
+character(len=1)   :: char_debug1      ! debug character (test only) 
 
 ! Iteration variables
 ! iteration converges if |dh_buoyancy - dh_buoyancy_prev| < epsa + epsr*dh_buoyancy
 integer                  :: it               ! iteration index
 logical                  :: converged        ! iteration has converged
 real                     :: dh_buoyancy_prev ! plume rise of previous iteration
-integer, parameter       :: maxit = 10       ! maximal number of iterations
+integer, parameter       :: maxit = 10       ! maximal number of iterations 
 real, parameter          :: epsa = 0.1       ! absolute error tolerance (m)
-real, parameter          :: epsr = 0.05      ! relative error tolerance
-
+real, parameter          :: epsr = 0.05      ! relative error tolerance 
+                                          
 !-------------------------------------------------------------------------------------------------------------------------------
 ! MS Briggs is developed for large stacks (energy production,..); should not be used for low emissions, e.g. emissions from animal housing.
 
@@ -418,14 +414,14 @@ if ( qw .gt. (0. + EPS_DELTA)) then
    !Initialization
    u_plume = u_stack
    dh_buoyancy = 0.0
-   ! if (prelim1) write(*,'(a,2(1x,e12.5))') 'ops_plumerise_buoyancy a',hemis0,u_stack
+   ! if (prelim1) write(*,'(a,2(1x,e12.5))') 'ops_plumerise_buoyancy a',hemis0,u_stack 
 
-   ! f = stack buoyancy flux (4.5 in 'The OPS-model Description of OPS 4.5.0). Briggs 1982, eq. 11. Assumed that Ps/Pa = 1.
+   ! f = stack buoyancy flux (4.5 in 'The OPS-model Description of OPS 4.5.0). Briggs 1982, eq. 11. Assumed that Ps/Pa = 1. 
    ! f = g/(pi*0.0013*T)*qw = 9.81/(3.14*0.0013*273)*qw    ! 0.0013 = rho*cp*fac_W_to_MW = 1.293*1005*1e-6
    ! f = 8.8*qw
    f = (grav*1.0e6/(pi*rho0*Cp0*T0))*qw
-
-   ! We want to use a wind speed that is representative for the whole plume rise length,
+   
+   ! We want to use a wind speed that is representative for the whole plume rise length, 
    ! but because we don't know the plume rise yet, we need an iteration.
    ! Initialisation for iteration:
    converged = .false.
@@ -433,8 +429,8 @@ if ( qw .gt. (0. + EPS_DELTA)) then
    dh_buoyancy_prev = -999.
 
    ! Do iteration:
-   do while (.not. converged .and. it .le. maxit)
-
+   do while (.not. converged .and. it .le. maxit) 
+   
       ! plume rise for unstable or neutral conditions, L < 0 or |L| > 50 (Eq 4.3 - 4.4 in 'The OPS-model Description of OPS 4.5.0):
       ! original value plrise_nonstab_Fbsplit = 55
       if ( non_stable ) then
@@ -442,7 +438,7 @@ if ( qw .gt. (0. + EPS_DELTA)) then
             dh_buoyancy = 38.8*f**0.6/u_plume                                 ! Briggs 1971 (as in the Dutch Nat. Mod.)
             ! char_debug1 = 'd'
          else
-            dh_buoyancy = 21.3*f**0.75/u_plume
+            dh_buoyancy = 21.3*f**0.75/u_plume                               
             ! char_debug1 = 'c'
          endif
      else
@@ -450,13 +446,13 @@ if ( qw .gt. (0. + EPS_DELTA)) then
         ! use fixed potential temperature gradient dtheta/dz = 0.006 (K/m); is valid for conditions above mixing layer.
         ! For low emissions and stable atmospheric conditions, dtheta/dz = 0.2 K/m
         ! original value: plrise_stab_dtheta_dz = 0.006
-         s    = 9.81/Ta_stack*dthetadz_stable         ! Stability parameter, Briggs (1969) Eq. 4.16.
-         dh_buoyancy = 2.6*(f/(s*u_plume))**0.333     ! Briggs 1982, Eq. 59.
-
+         s    = 9.81/Ta_stack*dthetadz_stable         ! Stability parameter, Briggs (1969) Eq. 4.16. 
+         dh_buoyancy = 2.6*(f/(s*u_plume))**0.333     ! Briggs 1982, Eq. 59. 
+         
          ! Check with old code of routine voorlpl:
          ! if (prelim1) then
-         !    ! voorlpl: dh_buoyancy = 65.*(qw/u_plume)**.333
-         !    ! 2.6*(f/(s*u_plume))**0.333 = 2.6*(8.8*qw/(s*u_plume))**0.333 = 2.6*(8.8**.333)*((1/s)**.333)*(qw/u_plume)**.333
+         !    ! voorlpl: dh_buoyancy = 65.*(qw/u_plume)**.333 
+         !    ! 2.6*(f/(s*u_plume))**0.333 = 2.6*(8.8*qw/(s*u_plume))**0.333 = 2.6*(8.8**.333)*((1/s)**.333)*(qw/u_plume)**.333 
          !    write(*,'(a,7(1x,e12.5))') 'ops_plumerise_buoyancy b',hemis0,dh_buoyancy,2.6*(f/s)**0.333,65.*qw**0.333,(grav*1.0e6/(pi*rho0*Cp0*T0)),2.6*((grav*1.0e6/(pi*rho0*Cp0*T0))**.333)*((1.0/s)**.333),Ta_stack
          !    char_debug1 = 'b'
          ! endif
@@ -464,7 +460,7 @@ if ( qw .gt. (0. + EPS_DELTA)) then
 
       ! Check for convergence:
       converged = (abs(dh_buoyancy - dh_buoyancy_prev) .lt. epsa + epsr*dh_buoyancy )
-
+      
       ! Update for next iteration:
       if (.not. converged .and. it .lt. maxit) then
          ! Compute wind speed at z = h_stack + 1/2 plume_rise:
@@ -492,7 +488,7 @@ if ( qw .gt. (0. + EPS_DELTA)) then
 
 ELSE
    ! Qw = 0
-   dh_buoyancy = 0.0
+   dh_buoyancy = 0.0 
 ENDIF
 
 end subroutine ops_plumerise_buoyancy
@@ -520,18 +516,18 @@ subroutine ops_plumerise_momentum(u_stack,D_stack,V_stack,Ts_stack,Ta_stack,dthe
 !       Gaussian Plume Air Dispersion Model
 !       https://www.weblakes.com/guides/iscst3/section6/6_1_4.html  (14-2-2018)
 
-use m_commonconst, only: EPS_DELTA
+use m_commonconst, only: EPS_DELTA                      
 use m_ops_utils, only: is_missing
 
 ! Input:
 real   , intent(in)  :: u_stack              ! wind speed at stack height [m/s]. For low sources the threshold height of 10m is applied.
 real   , intent(in)  :: D_stack              ! stack internal diameter [m]
 real   , intent(in)  :: V_stack              ! exit velocity of plume at stack tip [m/s]
-real   , intent(in)  :: Ts_stack             ! temperature of effluent from stack [K]
+real   , intent(in)  :: Ts_stack             ! temperature of effluent from stack [K] 
 real   , intent(in)  :: Ta_stack             ! ambient temperature at stack height [K]
 real   , intent(in)  :: dthetadz_stable      ! fixed potential temperature gradient dtheta/dz [K/m] for stable conditions, used for dh_buoyancy and dh_momentum
 logical, intent(in)  :: non_stable           ! non-stable (unstable/neutral) conditions
-
+                                     
 ! Output:
 real   , intent(out) :: dh_momentum          ! plume rise due to momentum [m]
 
@@ -544,16 +540,16 @@ if (V_stack .le. 0.0) then
    dh_momentum = 0.0
 else
 
-   ! Plume rise due to momentum for non-stable (unstable/neutral) conditions (Briggs, 1969, Eq. 5.2)
-   dh_nonstable = 3*D_stack*V_stack/u_stack
-
+   ! Plume rise due to momentum for non-stable (unstable/neutral) conditions (Briggs, 1969, Eq. 5.2) 
+   dh_nonstable = 3*D_stack*V_stack/u_stack 
+   
    ! Plume rise due to momentum for stable conditions:
    !                      2        2
    !                    Vs  D_stack    1/3     1/2        -1/6
-   !     dh = 0.646 [ --------------- ]    (Ta)     (dTdz)
+   !     dh = 0.646 [ --------------- ]    (Ta)     (dTdz)      
    !                      Ts  Us
    ! This originates from (Briggs 1969: Eq. 4.28, 4.19b, 4.16), see also Turner et al. (1986):
-   !              Fm     1/3     -1/6              rhos       2     2     Ps*Ta       2               2              g   dtheta
+   !              Fm     1/3     -1/6              rhos       2     2     Ps*Ta       2               2              g   dtheta  
    ! dh = 1.5 [ ------- ]     [s]        ;  Fm =  ------  (Vs)  (r0)  =  -------- (Vs)  0.25 (D_stack)     ;  s = [ ---  ------ ]
    !            u_stack                             rho                   P*Ts                                       Ta    dz
    ! with:
@@ -566,9 +562,9 @@ else
    ! P    = pressure ambient air, Ps = pressure of gases emitted from the stack, R = gas constant
    ! Ta   = average absolute temperature of ambient air (K) ( = Ta_stack below)
    ! Ts   = temperature of gases emitted from the stack (K) ( = Ts_stack below)
-
+   
    ! This can be rewritten to (assuming Ps/P = 1):
-   !                                        2        2                                                      2        2
+   !                                        2        2                                                      2        2  
    !                1/3      -1/6    Ps   Vs  D_stack    1/3     1/3     1/6            -1/6              Vs  D_stack    1/3     1/2             -1/6
    ! dh = 1.5 * 0.25   * 9.81     [ ---- -------------- ]    (Ta)    (Ta)    (dtheta/dz)      =  0.646 [ -------------- ]    (Ta)     (dtheta/dz)
    !                                 P    Ts  u_stack                                                     Ts  u_stack
@@ -576,37 +572,37 @@ else
    ! For stable conditions, the lower value of dh_nonstable and dh_stable is chosen (see also Turner et al., 1986)
    dh_stable = 0.646 * (( (V_stack**2.)*(D_stack**2.) / (Ts_stack*u_stack) )**(1./3.)) * (Ta_stack**0.5) * (dthetadz_stable**(-1./6.))
    if (dh_stable > dh_nonstable) dh_stable = dh_nonstable
-
+   
    ! Set output plume rise dh_momentum, depending on stability:
    if (non_stable) then
       dh_momentum = dh_nonstable
-   else
+   else 
       dh_momentum = dh_stable
    endif
 
 endif
 
-end subroutine ops_plumerise_momentum
+end subroutine ops_plumerise_momentum 
 
 !------------------------------------------------------------
-subroutine ops_plume_penetration(hemis0,zmix,zmix_loc,ol,dh,hemis1,onder)
+subroutine ops_plume_penetration(hemis0,zmix,zmix_loc,ol,dh,hemis1,onder) 
 !
-! Subroutine to determine whether there is plume penetration.
+! Subroutine to determine whether there is plume penetration. 
 !
-use m_commonconst, only: EPS_DELTA
+use m_commonconst, only: EPS_DELTA                      
 
-! Input
+! Input                          
 real, intent(in)    :: hemis0     ! initial emission height = stack height [m]
-real, intent(in)    :: zmix       ! mixing height [m]
+real, intent(in)    :: zmix       ! mixing height [m] 
 real, intent(in)    :: zmix_loc   ! mixing height, local scale [m]
 real, intent(in)    :: ol         ! Monin-Obukhov length [m]
 real, intent(in)    :: dh         ! plume rise due to either buoyancy or momentum [m]
 
-! Input/Output
+! Input/Output                   
 real, intent(inout) :: hemis1     ! emission height, including plume rise [m]
 
-! Output
-real, intent(out)   :: onder      ! part of plume below mixing height
+! Output                         
+real, intent(out)   :: onder      ! part of plume below mixing height 
 ! The emission distribution of an area source has a sigma equal to the height of the source hemis0.
 ! If hemis0 is close to the inversion height, the emission must be distributed over mixing layer and reservoir layer.
 ! last change: 21 Oct 2002
@@ -618,7 +614,7 @@ real, intent(out)   :: onder      ! part of plume below mixing height
 ! onder = 1 -> plume completely below mixing height
 ! onder = 0 -> plume completely above mixing height
 if( (hemis0 .gt. zmix + EPS_DELTA) .or. (hemis1 .le. hemis0 + EPS_DELTA) ) then
-   onder = (zmix - hemis1)/zmix + 0.5   ! OPS
+   onder = (zmix - hemis1)/zmix + 0.5   ! OPS   
 else
    onder = (zmix - hemis1)/dh + 0.5   ! Briggs (1975) and NNM
 endif
@@ -630,8 +626,8 @@ endif
 !
 ! Stable and unstable conditions and stack < mixing height -> add extra amount plrise_ci_add_stab_unstab to onder;
 
-if ( hemis0 .lt. zmix_loc .and. abs(ol) .lt. 100 ) then
-   onder = onder + 0.35
+if ( hemis0 .lt. zmix_loc .and. abs(ol) .lt. 100 ) then   
+   onder = onder + 0.35  
 endif
 
 ! Limit onder, such that 0 <= onder <= 1
@@ -641,7 +637,7 @@ else if (onder .LT. (0. - EPS_DELTA)) then
    onder = 0.
 else
    continue
-endif
+endif 
 
 ! Plume centre is maximal equal to mixing haight:
 if ((hemis1 .gt. (zmix + EPS_DELTA)) .and. (onder .gt. (0. + EPS_DELTA))) then

--- a/m_ops_utils.f90
+++ b/m_ops_utils.f90
@@ -1,22 +1,18 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
-!-------------------------------------------------------------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 module m_ops_utils
 
 ! Different utility routines and functions
@@ -109,7 +105,7 @@ real function angle180(a)
 use Binas, only: pi
 
 ! Return angle in interval (-pi,pi]
-! Input
+! Input 
 real, intent(in) ::  a            ! angle [radians]
 
 ! Local
@@ -165,7 +161,7 @@ e1y = v2y - v1y;
 ! e2 = p-v1:
 e2x = px - v1x;
 e2y = py - v1y;
-
+   
 ! Dot product of e1, e2:
 dot_prod = e1x*e2x + e1y*e2y;
 

--- a/m_ops_vchem.f90
+++ b/m_ops_vchem.f90
@@ -20,56 +20,40 @@
 !                      The Netherlands
 !   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
-! FUNCTION
-! NAME               : %M%
-! SCCS (SOURCE)      : %P%
+! MODULE             : m_ops_vchem
+! FILENAME           : %M%
+! SCCS(SOURCE)       : %P%
 ! RELEASE - LEVEL    : %R% - %L%
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
 ! AUTHOR             : OPS-support   
-! FIRM/INSTITUTE     : RIVM/LLO
-! LANGUAGE           : FORTRAN-77/90
-! DESCRIPTION        : Compute distance between (virtual point source) and (centre of area source);
-!                      for a point source, ops_virtdist = 0.
+! FIRM/INSTITUTE     : RIVM
+! LANGUAGE           : FORTRAN-F90
+! DESCRIPTION        : Define structure for chemical conversion rates
 ! EXIT CODES         :
 ! FILES AND OTHER    :
 !    I/O DEVICES
-! SYSTEM DEPENDENCIES: HP Fortran
+! SYSTEM DEPENDENCIES: 
 ! CALLED FUNCTIONS   :
-! UPDATE HISTORY     :
+! UPDATE HISTORY :
 !-------------------------------------------------------------------------------------------------------------------------------
-FUNCTION ops_virtdist (radius, rond)
+MODULE m_ops_vchem
 
-USE m_commonconst
+USE m_aps
 
 IMPLICIT NONE
 
-! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-INTEGER*4, INTENT(IN)                            :: rond                       ! 
+type Tvchem
+  
+   TYPE (TApsGridReal) :: mass_prec_grid               ! APS grid with column averaged mass of precursor pre chemistry step (from chemistry model, e.g. EMEP) [ug/m2]
+   TYPE (TApsGridReal) :: mass_conv_dtfac_grid         ! APS grid with (100/dt) * column averaged mass, converted during chemistry step (from chemistry model, e.g. EMEP) [(ug/m2) (%/h)]
 
-! RESULT
-REAL*4                                           :: ops_virtdist               ! 
+   real                :: mass_prec_tra                ! column averaged mass of precursor pre chemistry step, average between source - receptor [ug/m2]
+   real                :: mass_conv_dtfac_tra          ! (100/dt) * column averaged mass, converted during chemistry step, average between source - receptor [(ug/m2) (%/h)]
 
-! SCCS-ID VARIABLES
-CHARACTER*81                                     :: sccsida                    ! 
-sccsida = '%W%:%E%'//char(0)
-!-------------------------------------------------------------------------------------------------------------------------------
-!
-! Compute distance between (virtual point source) and (centre of area source);
-! for radius = 0 (point source), ops_virtdist = 0.
-! 3.33 OPS report
-!
-IF (rond .EQ. 1) THEN
-   ! Circular area source
-   ops_virtdist = (radius*12.)/PI 
-ELSE
-   ! Square area source is represented by a circular area source with the same area;
-   ! (area circle with radius r) = (area square with 1/2 side = radius) <=> pi*r**2 = (2*radius)**2 <=> 
-   ! <=> r = (2/sqrt(pi))*radius <=> r = 1.128*radius
-   ops_virtdist = (radius*12.)/PI*1.128
-ENDIF
+   real                :: vchem                        ! chemical conversion rates for net reaction primary -> secondary species [%/h]
 
-RETURN
-END
+end type Tvchem
+
+END MODULE m_ops_vchem

--- a/m_string.f90
+++ b/m_string.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! MODULE             : string
 ! IMPLEMENTS         : Collection of useful string routines.
@@ -29,7 +32,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Martien de Haan (ARIS)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! EXIT CODES         :

--- a/m_utils.f90
+++ b/m_utils.f90
@@ -302,7 +302,7 @@ SUBROUTINE allocreal0(dim, arr, error)
 INTEGER*4, INTENT(IN)                            :: dim                        ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT), DIMENSION(:), POINTER    :: arr                        ! 
+real,      INTENT(OUT), DIMENSION(:), POINTER    :: arr
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
 
 ! CONSTANTS
@@ -324,11 +324,11 @@ SUBROUTINE allocreal(dim, defvalue, arr, error)
 !DEC$ ATTRIBUTES DLLEXPORT:: allocreal
 
 ! SUBROUTINE ARGUMENTS - INPUT
-INTEGER*4, INTENT(IN)                            :: dim                        ! 
-REAL*4,    INTENT(IN)                            :: defvalue                   ! 
+INTEGER*4, INTENT(IN)                            :: dim
+real,      INTENT(IN)                            :: defvalue
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT), DIMENSION(:), POINTER    :: arr                        ! 
+real,      INTENT(OUT), DIMENSION(:), POINTER    :: arr
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
 
 ! LOCAL VARIABLES
@@ -387,7 +387,7 @@ SUBROUTINE allocdouble(dim, defvalue, arr, error)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: dim                        ! 
-REAL*4,    INTENT(IN)                            :: defvalue                   ! 
+real,      INTENT(IN)                            :: defvalue
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 DOUBLE PRECISION,    INTENT(OUT), DIMENSION(:), POINTER    :: arr                        ! 
@@ -427,7 +427,7 @@ INTEGER*4, INTENT(IN)                            :: dim1                       !
 INTEGER*4, INTENT(IN)                            :: dim2                       ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT), DIMENSION(:,:), POINTER  :: arr                        ! 
+real,      INTENT(OUT), DIMENSION(:,:), POINTER  :: arr
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
 
 ! LOCAL VARIABLES
@@ -462,7 +462,7 @@ INTEGER*4, INTENT(IN)                            :: dim1                       !
 INTEGER*4, INTENT(IN)                            :: dim2                       ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT), DIMENSION(:,:), ALLOCATABLE :: arr                        ! 
+real,      INTENT(OUT), DIMENSION(:,:), ALLOCATABLE :: arr
 TYPE (TError), INTENT(OUT)                          :: error                      ! Error handling record
 
 ! LOCAL VARIABLES
@@ -535,7 +535,7 @@ INTEGER*4, INTENT(IN)                            :: dim2                       !
 INTEGER*4, INTENT(IN)                            :: dim3                       ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT), DIMENSION(:,:,:), POINTER :: arr                       ! 
+real,      INTENT(OUT), DIMENSION(:,:,:), POINTER :: arr
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
 
 ! LOCAL VARIABLES
@@ -737,7 +737,7 @@ SUBROUTINE deallocreal(arr)
 !DEC$ ATTRIBUTES DLLEXPORT:: deallocreal
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT), DIMENSION(:), POINTER  :: arr                        ! 
+real,      INTENT(INOUT), DIMENSION(:), POINTER  :: arr
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -776,7 +776,7 @@ SUBROUTINE deallocreal2(arr)
 !DEC$ ATTRIBUTES DLLEXPORT:: deallocreal2
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT), DIMENSION(:,:), POINTER :: arr                       ! 
+real,      INTENT(INOUT), DIMENSION(:,:), POINTER :: arr
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -816,7 +816,7 @@ SUBROUTINE deallocreal3(arr)
 !DEC$ ATTRIBUTES DLLEXPORT:: deallocreal3
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT), DIMENSION(:,:,:), POINTER :: arr                     ! 
+real,      INTENT(INOUT), DIMENSION(:,:,:), POINTER :: arr
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -916,7 +916,7 @@ SUBROUTINE getreal  (string, value, nopart, error)
 CHARACTER*(*), INTENT(IN)                        :: string                     ! String with real number, starting at pos. 1.
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: value                      ! 
+real,      INTENT(OUT)                           :: value
 LOGICAL,   INTENT(OUT)                           :: nopart                     ! TRUE als er geen real is gelezen
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
 
@@ -924,7 +924,7 @@ TYPE (TError), INTENT(OUT)                       :: error                      !
 INTEGER*4                                        :: beyondpos                  ! First position beyond integer in string
 INTEGER*4                                        :: morepos                    ! First position beyond integer in substring
 INTEGER*4                                        :: intpart                    ! Extracted integer from string
-REAL*4                                           :: decpart                    ! Extracted decimal part from string
+real                                             :: decpart                    ! Extracted decimal part from string
 LOGICAL                                          :: nodecpart                  ! TRUE als er geen real is gelezen
 LOGICAL                                          :: negative                   ! Of getal negatief is
 CHARACTER                                        :: testchar                   ! Character looked at
@@ -1089,7 +1089,7 @@ END SUBROUTINE getint
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE byteswap1(ishort, shortdim)
 
-!DEC$ ATTRIBUTES DLLEXPORT:: byteswap1 
+!DEC$ ATTRIBUTES DLLEXPORT:: byteswap1
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: shortdim                   ! number of elements in ishort
@@ -1641,14 +1641,14 @@ INTEGER*4, INTENT(IN)                            :: nobs                       !
 INTEGER*4, INTENT(IN)                            :: column                     ! 
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: matrix(:,:)                ! 
+real,      INTENT(INOUT)                         :: matrix(:,:)
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: i                          ! 
 INTEGER*4                                        :: j                          ! 
 INTEGER*4                                        :: ctr                        ! 
 INTEGER*4                                        :: isize                      ! 
-REAL*4,    ALLOCATABLE                           :: tmp(:)                     ! 
+real,      ALLOCATABLE                           :: tmp(:)
 
 isize=SIZE(matrix,DIM=1)
 ALLOCATE(tmp(isize))

--- a/m_utils.f90
+++ b/m_utils.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME             : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE    : %B% - %S%
 ! DATE - TIME          : %E% - %U%
 ! WHAT                 : %W%:%E%
-! AUTHOR               : Martien de Haan, okt 2001
+! AUTHOR               : OPS-support   
 ! FIRM/INSTITUTE       : RIVM/LLO/IS
 ! LANGUAGE             : FORTRAN-77/90
 ! DESCRIPTION          : General utilities
@@ -77,7 +80,8 @@ IMPLICIT NONE
 INTERFACE Alloc
   MODULE PROCEDURE allocreal0                                                  ! allocation of real array (def=0.0)
   MODULE PROCEDURE allocreal                                                   ! allocation of real array
-  MODULE PROCEDURE allocreal2                                                  ! allocation of 2-dimensional real array
+  MODULE PROCEDURE allocreal2                                                  ! allocation of 2-dimensional real array (pointer)
+  MODULE PROCEDURE allocreal2a                                                  ! allocation of 2-dimensional real array (allocatable)
   MODULE PROCEDURE allocreal3                                                  ! allocation of 3-dimensional real array
   MODULE PROCEDURE allocdouble0                                                ! allocation of double array (def = 0.0)
   MODULE PROCEDURE allocdouble                                                 ! allocation of double array
@@ -167,7 +171,7 @@ END INTERFACE
 !-------------------------------------------------------------------------------------------------------------------------------
 ! FUNCTION    : WisselBytes
 ! DESCRIPTION : Converts integer*2 internal notation from HP fortran to Microsoft Fortran and visa versa
-! AUTHOR      : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR      : OPS-support   
 ! INPUTS      : string     (character*(*)) The string which should represent the number to be extracted.
 ! OUTPUTS     : default    (logical) Returns .TRUE. if no value was read because no value was defined following the = sign.
 !               error      (type TError). Is assigned when an error occurred in the number defined in the string.
@@ -183,7 +187,7 @@ END INTERFACE
 ! PURPOSE     : Initial assignment to a format string.
 ! DESCRIPTION : To be called when starting the creation of a format string. The format string is then extended through
 !               AppendFormat and PrependFormat.
-! AUTHOR      : Martien de Haan (ARIS).
+! AUTHOR      : OPS-support   .
 ! OUTPUTS     : formatstring (character*(*)) The formnat string to be created.
 !               error      (type TError). Is assigned when an error occurred in the assignment FormatString.
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -200,7 +204,7 @@ END INTERFACE
 ! REMARK      : AppendFormat checks first whether an error has occurred. If so nothing happens. This is handy, because the
 !               calling procedure only has to check the error status once after all append and prepend procedures have been
 !               called.
-! AUTHOR      : Martien de Haan (ARIS).
+! AUTHOR      : OPS-support   .
 ! INPUTS      : nrelts     (integer*4, optional) Assigns how many descriptor fields are present (that is number of integers,
 !                          floats or whatever in the format string).
 !               descriptor (character*(*)) The descriptor appended, such as 'I6', or 'F7.3' or 'X, I3'. This descriptor is
@@ -218,7 +222,7 @@ END INTERFACE
 ! PURPOSE     : Puts format descriptor at beginning of a format string.
 ! DESCRIPTION : See AppendFormat.
 ! REMARK      : See AppendFormat.
-! AUTHOR      : Martien de Haan (ARIS).
+! AUTHOR      : OPS-support   .
 ! INPUTS      : nrelts     (integer*4, optional) Assigns how many descriptor fields are present (that is number of integers,
 !                          floats or whatever in the format string).
 !               descriptor (character*(*)) The descriptor appended, such as 'I6', or 'F7.3' or 'X, I3'. This descriptor is
@@ -444,6 +448,41 @@ IF (.NOT. error%haserror .AND. dim1 > 0 .AND. dim2 > 0) THEN
 ENDIF
 
 END SUBROUTINE allocreal2
+!-------------------------------------------------------------------------------------------------------------------------------
+! SUBROUTINE           : allocreal2
+! INTERFACE            : Alloc
+! PURPOSE              : Allocation of 2-dimensional real array.
+!-------------------------------------------------------------------------------------------------------------------------------
+SUBROUTINE allocreal2a(dim1, dim2, arr, error)
+
+!DEC$ ATTRIBUTES DLLEXPORT:: allocreal2a
+
+! SUBROUTINE ARGUMENTS - INPUT
+INTEGER*4, INTENT(IN)                            :: dim1                       ! 
+INTEGER*4, INTENT(IN)                            :: dim2                       ! 
+
+! SUBROUTINE ARGUMENTS - OUTPUT
+REAL*4,    INTENT(OUT), DIMENSION(:,:), ALLOCATABLE :: arr                        ! 
+TYPE (TError), INTENT(OUT)                          :: error                      ! Error handling record
+
+! LOCAL VARIABLES
+INTEGER*4                                        :: ierr                       ! 
+
+! CONSTANTS
+CHARACTER*512                                    :: ROUTINENAAM                ! 
+PARAMETER     (ROUTINENAAM = 'allocreal2')
+
+!-------------------------------------------------------------------------------------------------------------------------------
+IF (.NOT. error%haserror .AND. dim1 > 0 .AND. dim2 > 0) THEN
+  ALLOCATE(arr(dim1, dim2), stat=ierr)
+
+  IF (ierr /= 0) THEN
+    CALL AllocError(ierr, ROUTINENAAM, dim1, '2-dimensional real', error)
+    CALL ErrorParam('second dimension', dim2, error)
+  ENDIF
+ENDIF
+
+END SUBROUTINE allocreal2a
 
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE           : allocdouble2
@@ -985,7 +1024,7 @@ END SUBROUTINE getreal
 
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE           : getint
-! AUTHOR               : Martien de Haan, okt 2001
+! AUTHOR               : OPS-support   
 ! PURPOSE              : Extraheren van integer waarde uit een string. Geeft terug of er een waarde was, welke positie, etc.
 ! CALLED FUNCTIONS     : extractint
 !-------------------------------------------------------------------------------------------------------------------------------
@@ -1114,7 +1153,7 @@ END SUBROUTINE byteswap2
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE  : byteswap
 ! DESCRIPTION : Converts integer*2 internal notation from HP fortran to Microsoft Fortran and visa versa.
-! AUTHOR      : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR      : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE byteswap(ishort)
 
@@ -1146,11 +1185,6 @@ ELSE
 ENDIF
 k1 = mod(ishort, maxint2)
 k2 = ishort/maxint2
-!! The following code may lead to overflow 
-!! j  = k1*maxint2 + k2 + iflg
-!! IF ( j .GT. 32768 ) THEN
-!!   j = j - 65536
-!! ENDIF
 IF (k1 > 128) THEN ! 32768/maxint2 = 128
    j  = (k1-256)*maxint2 + k2 + iflg ! 256*maxint2 = 65536
 ELSE
@@ -1159,6 +1193,7 @@ ELSE
       j = j - 65536
    ENDIF
 ENDIF
+
 ishort = j
 
 RETURN
@@ -1283,15 +1318,6 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER     (ROUTINENAAM = 'GetOS')
 
 rtc = GETCWD(directory)
-
-!! ! GETCWD is compiler dependent; alternative with IFNDEF Unix:
-!! #ifndef UNIX
-!!    os = 1   ! Windows
-!!    IF (PRESENT(slash)) slash = '\'
-!! #else
-!!    os = 0   ! Unix
-!!    IF (PRESENT(slash)) slash = '/'
-!! #endif
 
 colonpos = INDEX(directory,':')
 

--- a/ops_bgcon.f90
+++ b/ops_bgcon.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME           : %M%
@@ -24,10 +27,11 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Hans van Jaarveld/Martien de Haan
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77, HP-F90)
-! DESCRIPTION        : Returns background concentration at a specific location.
+! DESCRIPTION        : Returns grid value at a specific location. 
+!                      Originally made for background concentrations (bgcon), but now also used for other grids. 
 ! EXIT CODES         :
 ! FILES AND OTHER    :
 !    I/O DEVICES
@@ -35,7 +39,11 @@
 ! CALLED FUNCTIONS   :
 ! UPDATE HISTORY     :
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_bgcon(x, y, bgdata, bgcon)
+module m_ops_bgcon
+
+contains
+
+SUBROUTINE ops_bgcon(x, y, bgdata, bgcon, fieldnumber)
 
 USE m_aps
 USE m_commonconst                                                              ! EPS_DELTA only
@@ -50,6 +58,7 @@ PARAMETER    (ROUTINENAAM = 'ops_bgcon')
 REAL*4,    INTENT(IN)                            :: x                          ! x coordinate of specific location
 REAL*4,    INTENT(IN)                            :: y                          ! y coordinate of specific location
 TYPE (TApsGridReal), INTENT(IN)                  :: bgdata                     ! APS-grid with background concentrations
+INTEGER, OPTIONAL                                :: fieldnumber                ! field number in APS-grid
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 REAL*4,    INTENT(OUT)                           :: bgcon                      ! background concentration at (x,y)
@@ -58,16 +67,23 @@ REAL*4,    INTENT(OUT)                           :: bgcon                      !
 LOGICAL                                          :: iscell                     ! whether (x,y) is inside APS-grid bgdata
 !-------------------------------------------------------------------------------------------------------------------------------
 !
-! Get value of background concentration bgdata at location (x,y).
+! Get value of background concentration bgdata at location (x,y); return grid average if point is outside grid or if value is negative 
 ! Note: arguments of GridValue must be in km
 !
-CALL GridValue(x/1000., y/1000., bgdata, bgcon, iscell)
-!
-! Get value from background grid. If point (x,y) is outside background grid, the average background value is returned.
-! 
-IF (iscell .AND. bgcon < 0.+EPS_DELTA) THEN 
-  bgcon = bgdata%average 
-ENDIF 
+if (present(fieldnumber)) then
+   CALL GridValue(x/1000., y/1000., bgdata, bgcon, iscell, fieldnumber)
+   IF (iscell .AND. bgcon < 0.+EPS_DELTA) THEN 
+     bgcon = bgdata%average(fieldnumber)
+   ENDIF
+else
+   CALL GridValue(x/1000., y/1000., bgdata, bgcon, iscell)
+   IF (iscell .AND. bgcon < 0.+EPS_DELTA) THEN 
+     bgcon = bgdata%average(1)
+   ENDIF
+endif
+! write(*,'(a,3(1x,e12.5),L3,1x,e12.5)') 'ops_bgcon: ',x,y,bgcon,iscell,bgdata%average  
 
 RETURN
 END SUBROUTINE ops_bgcon
+
+end module m_ops_bgcon

--- a/ops_bgcon.f90
+++ b/ops_bgcon.f90
@@ -55,13 +55,13 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_bgcon')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: x                          ! x coordinate of specific location
-REAL*4,    INTENT(IN)                            :: y                          ! y coordinate of specific location
+real,      INTENT(IN)                            :: x                          ! x coordinate of specific location
+real,      INTENT(IN)                            :: y                          ! y coordinate of specific location
 TYPE (TApsGridReal), INTENT(IN)                  :: bgdata                     ! APS-grid with background concentrations
 INTEGER, OPTIONAL                                :: fieldnumber                ! field number in APS-grid
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: bgcon                      ! background concentration at (x,y)
+real,      INTENT(OUT)                           :: bgcon                      ! background concentration at (x,y)
 
 ! LOCAL VARIABLES
 LOGICAL                                          :: iscell                     ! whether (x,y) is inside APS-grid bgdata

--- a/ops_bgcon_tra.f90
+++ b/ops_bgcon_tra.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Hans van Jaarveld/Martien de Haan
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77, HP-F90)
 ! DESCRIPTION        : This routine reads for a given location the background conc. and 
@@ -43,6 +46,7 @@
 SUBROUTINE ops_bgcon_tra(xr, yr, xb, yb, bgdata, bgcon)
 
 USE m_aps
+USE m_ops_bgcon
 
 IMPLICIT NONE
 
@@ -80,6 +84,7 @@ DO i=0,ns
 !
   x=xr+(xb-xr)/ns*i
   y=yr+(yb-yr)/ns*i
+  
 !
 ! Calculate background concentration contribution at this point and add to total
 !

--- a/ops_bgcon_tra.f90
+++ b/ops_bgcon_tra.f90
@@ -55,20 +55,20 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_bgcon_tra')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: xr                         ! x coordinate receptor
-REAL*4,    INTENT(IN)                            :: yr                         ! y coordinate receptor
-REAL*4,    INTENT(IN)                            :: xb                         ! x coordinate source (b << "bron" = source)
-REAL*4,    INTENT(IN)                            :: yb                         ! y coordinate source 
+real,      INTENT(IN)                            :: xr                         ! x coordinate receptor
+real,      INTENT(IN)                            :: yr                         ! y coordinate receptor
+real,      INTENT(IN)                            :: xb                         ! x coordinate source (b << "bron" = source)
+real,      INTENT(IN)                            :: yb                         ! y coordinate source
 TYPE (TApsGridReal), INTENT(IN)                  :: bgdata                     ! grid with background concentrations
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: bgcon                      ! background concentration averaged over trajecory 
+real,      INTENT(OUT)                           :: bgcon                      ! background concentration averaged over trajecory
                                                                                ! between source and receptor
 
 ! LOCAL VARIABLES
-REAL*4                                           :: x                          ! x coordinate of intermediate point between source and receptor
-REAL*4                                           :: y                          ! y coordinate of intermediate point between source and receptor
-REAL*4                                           :: total                      ! summed total of background concentration in intermediate points
+real                                             :: x                          ! x coordinate of intermediate point between source and receptor
+real                                             :: y                          ! y coordinate of intermediate point between source and receptor
+real                                             :: total                      ! summed total of background concentration in intermediate points
 INTEGER*4                                        :: ns                         ! number of trajectory sectors between intermediate points
 INTEGER*4                                        :: i                          ! index of intermediate point
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/ops_bron_rek.f90
+++ b/ops_bron_rek.f90
@@ -58,32 +58,32 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_bron_rek')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: emtrend  
+real,      INTENT(IN)                            :: emtrend
 type(TbuildingEffect)                            :: buildingEffect            ! structure with building effect tables                   
 
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT(INOUT)                         :: landmax                     
-REAL*4,    INTENT(INOUT)                         :: emis(6,NLANDMAX)           
+real,      INTENT(INOUT)                         :: emis(6,NLANDMAX)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: nsbuf                       
 INTEGER*4, INTENT(OUT)                           :: bnr(LSBUF)                  
 INTEGER*4, INTENT(OUT)                           :: bx(LSBUF)                   
 INTEGER*4, INTENT(OUT)                           :: by(LSBUF)                   
-REAL*4,    INTENT(OUT)                           :: bdiam(LSBUF)                
-REAL*4,    INTENT(OUT)                           :: bsterkte(LSBUF)             
-REAL*4,    INTENT(OUT)                           :: bwarmte(LSBUF)              
-REAL*4,    INTENT(OUT)                           :: bhoogte(LSBUF)              
-REAL*4,    INTENT(OUT)                           :: bsigmaz(LSBUF)  
-REAL*4,    INTENT(OUT)                           :: bD_stack(LSBUF)           ! diameter of the stack [m]
-REAL*4,    INTENT(OUT)                           :: bV_stack(LSBUF)           ! exit velocity of plume at stack tip [m/s]
-REAL*4,    INTENT(OUT)                           :: bTs_stack(LSBUF)          ! temperature of effluent from stack [K]            
+real,      INTENT(OUT)                           :: bdiam(LSBUF)
+real,      INTENT(OUT)                           :: bsterkte(LSBUF)
+real,      INTENT(OUT)                           :: bwarmte(LSBUF)
+real,      INTENT(OUT)                           :: bhoogte(LSBUF)
+real,      INTENT(OUT)                           :: bsigmaz(LSBUF)
+real,      INTENT(OUT)                           :: bD_stack(LSBUF)           ! diameter of the stack [m]
+real,      INTENT(OUT)                           :: bV_stack(LSBUF)           ! exit velocity of plume at stack tip [m/s]
+real,      INTENT(OUT)                           :: bTs_stack(LSBUF)          ! temperature of effluent from stack [K]
 LOGICAL,   INTENT(OUT)                           :: bemis_horizontal(LSBUF)   ! horizontal outflow of emission
 type(Tbuilding), INTENT(OUT)                     :: bbuilding(LSBUF)          ! array with structures with building parameters
 INTEGER*4, INTENT(OUT)                           :: btgedr(LSBUF)
 INTEGER*4, INTENT(OUT)                           :: bdegr(LSBUF)                
-REAL*4,    INTENT(OUT)                           :: bqrv(LSBUF)                 
-REAL*4,    INTENT(OUT)                           :: bqtr(LSBUF)                 
+real,      INTENT(OUT)                           :: bqrv(LSBUF)
+real,      INTENT(OUT)                           :: bqtr(LSBUF)
 INTEGER*4, INTENT(OUT)                           :: bcatnr(LSBUF)               
 INTEGER*4, INTENT(OUT)                           :: blandnr(LSBUF)              
 LOGICAL,   INTENT(OUT)                           :: eof                        ! end of file has been reached 
@@ -96,22 +96,22 @@ INTEGER*4                                        :: ibroncat                   !
 INTEGER*4                                        :: idgr                       ! 
 INTEGER*4                                        :: iland                      ! country code
 INTEGER*4                                        :: index                      ! index of country code iland, in list of country codes
-REAL*4                                           :: gl                         ! 
-REAL*4                                           :: gb                         ! 
-REAL*4                                           :: qtr                        ! 
-REAL*4                                           :: qob                        ! 
-REAL*4                                           :: x                          ! 
-REAL*4                                           :: y                          ! 
-REAL*4                                           :: diameter                   ! 
-REAL*4                                           :: qww                        ! 
-REAL*4                                           :: hbron                      ! 
-REAL*4                                           :: szopp                      ! 
-REAL*4                                           :: D_stack                    ! diameter of the stack [m]
-REAL*4                                           :: V_stack                    ! exit velocity of plume at stack tip [m/s]
-REAL*4                                           :: Ts_stack                   ! temperature of effluent from stack [K]            
+real                                             :: gl
+real                                             :: gb
+real                                             :: qtr
+real                                             :: qob
+real                                             :: x
+real                                             :: y
+real                                             :: diameter
+real                                             :: qww
+real                                             :: hbron
+real                                             :: szopp
+real                                             :: D_stack                    ! diameter of the stack [m]
+real                                             :: V_stack                    ! exit velocity of plume at stack tip [m/s]
+real                                             :: Ts_stack                   ! temperature of effluent from stack [K]
 LOGICAL                                          :: emis_horizontal            ! horizontal outflow of emission
 type(Tbuilding)                                  :: building                   ! structure with building paramaters
-REAL*4                                           :: qrv                        ! 
+real                                             :: qrv
 CHARACTER*512                                    :: cbuf                       ! character buffer
 REAL                                             :: valueArray(buildingEffect%nParam)  ! array with parameters needed to compute building effect
 INTEGER                                          :: iParam                     ! index of building parameter

--- a/ops_bron_rek.f90
+++ b/ops_bron_rek.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Hans van Jaarsveld, Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 !                      Chris Twenh"ofel (Cap Gemini)
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN-77/90

--- a/ops_brondepl.f90
+++ b/ops_brondepl.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/ Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77)
 ! DESCRIPTION        : Compute source depletion (brondepl << "bron" = source, depl << depletion).
@@ -368,7 +371,7 @@ ENDIF
 ! ugem: average wind speed depending on phase of plume development
 !
 ! source code:
-!                 2.*al*1.e-6*vg0tra*(xx - radius)     (xx + virty)*cxx*ueff*(1.-cgt)   2 pi   
+!                 2.*al*1.e-6*vg0tra*(xx - radius)     (xx + virty)*cxx*ueff*(1.-cgt)   2 pi    FS
 !    cq2 = EXP( - ----------------------------------  -------------------------------- ------) 
 !                              ugem                         onder*qbstf                  12    
 

--- a/ops_brondepl.f90
+++ b/ops_brondepl.f90
@@ -59,75 +59,75 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_brondepl')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: xg                         ! 
-REAL*4,    INTENT(IN)                            :: c                          ! undepleted concentration at z = 0 m
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: xg
+real,      INTENT(IN)                            :: c                          ! undepleted concentration at z = 0 m
                                                                                ! (without part of plume above mixing layer)
-REAL*4,    INTENT(IN)                            :: ux0                        ! wind speed near source at plume height (m/s)
-REAL*4,    INTENT(IN)                            :: ueff                       ! wind speed at effective transport height heff (m/s); 
+real,      INTENT(IN)                            :: ux0                        ! wind speed near source at plume height (m/s)
+real,      INTENT(IN)                            :: ueff                       ! wind speed at effective transport height heff (m/s);
                                                                                ! for short distances heff = plume height;
                                                                                ! for large distances heff = 1/2 mixing height;
                                                                                ! heff is interpolated for intermediate distances.
-REAL*4,    INTENT(IN)                            :: sigz                       ! 
-REAL*4,    INTENT(IN)                            :: vg50trans                  ! 
-REAL*4,    INTENT(IN)                            :: xl                         ! 
+real,      INTENT(IN)                            :: sigz
+real,      INTENT(IN)                            :: vg50trans
+real,      INTENT(IN)                            :: xl
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: xloc                       ! 
-REAL*4,    INTENT(IN)                            :: xl100                      ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: pcoef                      ! 
-REAL*4,    INTENT(IN)                            :: virty                      ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: ra4_rcp                    ! 
-REAL*4,    INTENT(IN)                            :: raz_rcp                    ! EvdS: hoogte afhankelijkheid 
-REAL*4,    INTENT(IN)                            :: rc_rcp                     ! 
-REAL*4,    INTENT(IN)                            :: rb_rcp                     ! 
-REAL*4,    INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: ol_src                     ! 
-REAL*4,    INTENT(IN)                            :: uster_src                  ! 
-REAL*4,    INTENT(IN)                            :: htot                       ! 
-REAL*4,    INTENT(IN)                            :: ra4src                     ! 
-REAL*4,    INTENT(IN)                            :: rb_src                      ! 
-REAL*4,    INTENT(IN)                            :: rcsrc                      ! 
-REAL*4,    INTENT(IN)                            :: qbstf                      ! 
-REAL*4,    INTENT(IN)                            :: vg0tra                     ! 
-REAL*4,    INTENT(IN)                            :: onder                      ! 
+real,      INTENT(IN)                            :: xloc
+real,      INTENT(IN)                            :: xl100
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: pcoef
+real,      INTENT(IN)                            :: virty
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: ra4_rcp
+real,      INTENT(IN)                            :: raz_rcp                    ! EvdS: hoogte afhankelijkheid
+real,      INTENT(IN)                            :: rc_rcp
+real,      INTENT(IN)                            :: rb_rcp
+real,      INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(IN)                            :: ol_src
+real,      INTENT(IN)                            :: uster_src
+real,      INTENT(IN)                            :: htot
+real,      INTENT(IN)                            :: ra4src
+real,      INTENT(IN)                            :: rb_src
+real,      INTENT(IN)                            :: rcsrc
+real,      INTENT(IN)                            :: qbstf
+real,      INTENT(IN)                            :: vg0tra
+real,      INTENT(IN)                            :: onder
 INTEGER*4, INTENT(IN)                            :: flag                       ! stable meteo class and stack emitting above mixing layer 
-REAL*4,    INTENT(IN)                            :: vchem                      ! 
-REAL*4,    INTENT(IN)                            :: vnatpri                    ! 
-REAL*4,    INTENT(IN)                            :: diameter                   ! 
-REAL*4,    INTENT(IN)                            :: dispg(NSTAB)               ! 
-REAL*4,    INTENT(IN)                            :: zm                         ! z-coordinate of receptor points (RDM)
+real,      INTENT(IN)                            :: vchem
+real,      INTENT(IN)                            :: vnatpri
+real,      INTENT(IN)                            :: diameter
+real,      INTENT(IN)                            :: dispg(NSTAB)
+real,      INTENT(IN)                            :: zm                         ! z-coordinate of receptor points (RDM)
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: cgt                        ! 
-REAL*4,    INTENT(INOUT)                         :: cgt_z                      ! height dependent cgt
+real,      INTENT(INOUT)                         :: cgt
+real,      INTENT(INOUT)                         :: cgt_z                      ! height dependent cgt
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: cdn                        ! 
-REAL*4,    INTENT(OUT)                           :: ugem                       ! average wind speed depending on phase of plume development (m/s)
-REAL*4,    INTENT(OUT)                           :: hf                         ! 
-REAL*4,    INTENT(OUT)                           :: a                          ! 
-REAL*4,    INTENT(OUT)                           :: cq1                        ! 
-REAL*4,    INTENT(OUT)                           :: cq2                        ! 
-REAL*4,    INTENT(OUT)                           :: uxr                        ! wind speed representative for plume over area source (m/s)
-REAL*4,    INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection 
+real,      INTENT(OUT)                           :: cdn
+real,      INTENT(OUT)                           :: ugem                       ! average wind speed depending on phase of plume development (m/s)
+real,      INTENT(OUT)                           :: hf
+real,      INTENT(OUT)                           :: a
+real,      INTENT(OUT)                           :: cq1
+real,      INTENT(OUT)                           :: cq2
+real,      INTENT(OUT)                           :: uxr                        ! wind speed representative for plume over area source (m/s)
+real,      INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection
                                                                                ! at the top of the mixing layer and at the ground surface
-REAL*4,    INTENT(OUT)                           :: sigzr                      ! 
-REAL*4,    INTENT(OUT)                           :: dxeff                      ! 
+real,      INTENT(OUT)                           :: sigzr
+real,      INTENT(OUT)                           :: dxeff
 
 ! LOCAL VARIABLES
-REAL*4                                           :: cxx                        ! representative concentration (undepleted) for plume in phase 2
-REAL*4                                           :: xx                         ! representative distance for plume in phase 2
-REAL*4                                           :: sigzxg                     ! sigma_z at xx
-REAL*4                                           :: xlxg                       ! 
-REAL*4                                           :: uxg                        ! 
-REAL*4                                           :: s2                         ! 
-REAL*4                                           :: vdoppb                     ! 
-REAL*4                                           :: sh                         ! 
-REAL*4                                           :: al                         ! 
+real                                             :: cxx                        ! representative concentration (undepleted) for plume in phase 2
+real                                             :: xx                         ! representative distance for plume in phase 2
+real                                             :: sigzxg                     ! sigma_z at xx
+real                                             :: xlxg
+real                                             :: uxg
+real                                             :: s2
+real                                             :: vdoppb
+real                                             :: sh
+real                                             :: al
 
 ! SUBROUTINE AND FUNCTION CALLS
 EXTERNAL ops_vertdisp

--- a/ops_calc_stats.f90
+++ b/ops_calc_stats.f90
@@ -53,12 +53,12 @@ PARAMETER    (ROUTINENAAM = 'ops_calc_stats')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptor points
 INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species
-REAL*4,    INTENT(IN)                            :: frac(nrrcp)                ! fraction per cell inside NL
-REAL*4,    INTENT(IN)                            :: cpri(nrrcp)                ! primary concentration [ug/m3]
-REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! secondary concentration [ug/m3]
-REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! dry deposition
-REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! wet deposition
-REAL*4,    INTENT(IN)                            :: gemre                      ! yearly mean precipitation from meteo statistics [mm/h]
+real,      INTENT(IN)                            :: frac(nrrcp)                ! fraction per cell inside NL
+real,      INTENT(IN)                            :: cpri(nrrcp)                ! primary concentration [ug/m3]
+real,      INTENT(IN)                            :: csec(nrrcp)                ! secondary concentration [ug/m3]
+real,      INTENT(IN)                            :: drydep(nrrcp)              ! dry deposition
+real,      INTENT(IN)                            :: wetdep(nrrcp)              ! wet deposition
+real,      INTENT(IN)                            :: gemre                      ! yearly mean precipitation from meteo statistics [mm/h]
 DOUBLE PRECISION, INTENT(IN)                     :: sdrypri                    ! 
 DOUBLE PRECISION, INTENT(IN)                     :: sdrysec                    ! 
 DOUBLE PRECISION, INTENT(IN)                     :: somvnpri                   ! 
@@ -67,47 +67,47 @@ DOUBLE PRECISION, INTENT(IN)                     :: vvchem                     !
 DOUBLE PRECISION, INTENT(IN)                     :: vtel                       ! 
 DOUBLE PRECISION, INTENT(IN)                     :: telvnpri                   ! 
 DOUBLE PRECISION, INTENT(IN)                     :: telvnsec                   ! 
-REAL*4,    INTENT(IN)                            :: grid                       ! 
-REAL*4,    INTENT(IN)                            :: conc_cf                    ! 
-REAL*4,    INTENT(IN)                            :: amol21                     ! 
-REAL*4,    INTENT(IN)                            :: ugmoldep                   ! 
-REAL*4,    INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
+real,      INTENT(IN)                            :: grid
+real,      INTENT(IN)                            :: conc_cf
+real,      INTENT(IN)                            :: amol21
+real,      INTENT(IN)                            :: ugmoldep
+real,      INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
 
 ! SUBROUTINE ARGUMENTS - I/O
 DOUBLE PRECISION, INTENT(INOUT)                  :: snatpri                    ! 
 DOUBLE PRECISION, INTENT(INOUT)                  :: snatsec                    ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: gemcpri                    ! grid mean for primary concentration [ug/m3]
-REAL*4,    INTENT(OUT)                           :: gemcsec                    ! grid mean for secondary concentration [ug/m3]
-REAL*4,    INTENT(OUT)                           :: totddep                    ! grid total dry deposition (g/s)
-REAL*4,    INTENT(OUT)                           :: gemddep                    ! grid mean for dry deposition ["depeh"]
-REAL*4,    INTENT(OUT)                           :: gemddpri                   ! grid mean for dry deposition of primary component ["depeh"]
-REAL*4,    INTENT(OUT)                           :: gemddsec                   ! grid mean for dry deposition of secondary component ["depeh"]
-REAL*4,    INTENT(OUT)                           :: ddrpri                     ! effective dry deposition velocity (primary component) [cm/s]
-REAL*4,    INTENT(OUT)                           :: ddrsec                     ! effective dry deposition velocity (secondary component) [cm/s]
-REAL*4,    INTENT(OUT)                           :: totwdep                    ! grid total wet deposition (g/s)
-REAL*4,    INTENT(OUT)                           :: gemwdep                    ! grid mean for wet deposition ["depeh"]
-REAL*4,    INTENT(OUT)                           :: gemwdpri                   ! grid mean for wet deposition of primary component ["depeh"]
-REAL*4,    INTENT(OUT)                           :: gemwdsec                   ! grid mean for wet deposition of secondary component ["depeh"]
-REAL*4,    INTENT(OUT)                           :: wdrpri                     ! effective wet deposition rate (primary component) [%/h]
-REAL*4,    INTENT(OUT)                           :: wdrsec                     ! effective wet deposition rate (secondary component) [%/h]
-REAL*4,    INTENT(OUT)                           :: gemprec                    ! grid mean yearly precipitation [mm]
-REAL*4,    INTENT(OUT)                           :: tottdep                    ! grid total of total deposition (g/s)
-REAL*4,    INTENT(OUT)                           :: gemtdep                    ! grid mean of total deposition ["depeh"]
-REAL*4,    INTENT(OUT)                           :: ccr                        ! effective chemical conversion rate [%/h]
-REAL*4,    INTENT(OUT)                           :: gem_subsec(nsubsec)        ! grid mean for concentration of sub-secondary species [ug/m3]
+real,      INTENT(OUT)                           :: gemcpri                    ! grid mean for primary concentration [ug/m3]
+real,      INTENT(OUT)                           :: gemcsec                    ! grid mean for secondary concentration [ug/m3]
+real,      INTENT(OUT)                           :: totddep                    ! grid total dry deposition (g/s)
+real,      INTENT(OUT)                           :: gemddep                    ! grid mean for dry deposition ["depeh"]
+real,      INTENT(OUT)                           :: gemddpri                   ! grid mean for dry deposition of primary component ["depeh"]
+real,      INTENT(OUT)                           :: gemddsec                   ! grid mean for dry deposition of secondary component ["depeh"]
+real,      INTENT(OUT)                           :: ddrpri                     ! effective dry deposition velocity (primary component) [cm/s]
+real,      INTENT(OUT)                           :: ddrsec                     ! effective dry deposition velocity (secondary component) [cm/s]
+real,      INTENT(OUT)                           :: totwdep                    ! grid total wet deposition (g/s)
+real,      INTENT(OUT)                           :: gemwdep                    ! grid mean for wet deposition ["depeh"]
+real,      INTENT(OUT)                           :: gemwdpri                   ! grid mean for wet deposition of primary component ["depeh"]
+real,      INTENT(OUT)                           :: gemwdsec                   ! grid mean for wet deposition of secondary component ["depeh"]
+real,      INTENT(OUT)                           :: wdrpri                     ! effective wet deposition rate (primary component) [%/h]
+real,      INTENT(OUT)                           :: wdrsec                     ! effective wet deposition rate (secondary component) [%/h]
+real,      INTENT(OUT)                           :: gemprec                    ! grid mean yearly precipitation [mm]
+real,      INTENT(OUT)                           :: tottdep                    ! grid total of total deposition (g/s)
+real,      INTENT(OUT)                           :: gemtdep                    ! grid mean of total deposition ["depeh"]
+real,      INTENT(OUT)                           :: ccr                        ! effective chemical conversion rate [%/h]
+real,      INTENT(OUT)                           :: gem_subsec(nsubsec)        ! grid mean for concentration of sub-secondary species [ug/m3]
 
 ! LOCAL VARIABLES
-REAL*4                                           :: somcsec                    ! sum of secondary concentrations [ug/m3]
-REAL*4                                           :: somddep                    ! sum of dry depositions ["depeh"]
-REAL*4                                           :: somwdep                    ! sum of wet depositions ["depeh"]
+real                                             :: somcsec                    ! sum of secondary concentrations [ug/m3]
+real                                             :: somddep                    ! sum of dry depositions ["depeh"]
+real                                             :: somwdep                    ! sum of wet depositions ["depeh"]
 
 ! LOCAL VARIABLES
-REAL*4                                           :: cf                         ! conversion factor
-REAL*4                                           :: somcpri                    ! sum of primary concentrations [ug/m3]
-REAL*4                                           :: som_subsec(nsubsec)        ! sum of concentrations of sub-secondary species [ug/m3]
-REAL*4                                           :: somfrac                    ! sum of frac
+real                                             :: cf                         ! conversion factor
+real                                             :: somcpri                    ! sum of primary concentrations [ug/m3]
+real                                             :: som_subsec(nsubsec)        ! sum of concentrations of sub-secondary species [ug/m3]
+real                                             :: somfrac                    ! sum of frac
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
 
 ! SCCS-ID VARIABLES

--- a/ops_conc_ini.f90
+++ b/ops_conc_ini.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                               copyright by
 !   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
+!             Laboratory for Air Research (RIVM/LLO)
+!                              The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Compute initial concentrations due to transport and dispersion; no removal processes yet.

--- a/ops_conc_ini.f90
+++ b/ops_conc_ini.f90
@@ -51,47 +51,47 @@ PARAMETER    (ROUTINENAAM = 'ops_conc_ini')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 LOGICAL,   INTENT(IN)                            :: gasv                       ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: htt                        ! plume height, excluding plume descent due to heavy particles [m]
-REAL*4,    INTENT(IN)                            :: pcoef                      ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: htt                        ! plume height, excluding plume descent due to heavy particles [m]
+real,      INTENT(IN)                            :: pcoef
+real,      INTENT(IN)                            :: disx
 INTEGER*4, INTENT(IN)                            :: kdeel                      ! 
-REAL*4,    INTENT(IN)                            :: qbpri                      ! 
-REAL*4,    INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m] 
-REAL*4,    INTENT(IN)                            :: szopp                      ! 
+real,      INTENT(IN)                            :: qbpri
+real,      INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(IN)                            :: szopp
 INTEGER*4, INTENT(IN)                            :: rond                       ! 
-REAL*4,    INTENT(IN)                            :: uster_src                  ! 
-REAL*4,    INTENT(IN)                            :: ol_src                     ! 
+real,      INTENT(IN)                            :: uster_src
+real,      INTENT(IN)                            :: ol_src
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
 INTEGER*4, INTENT(IN)                            :: iwd                        ! 
-REAL*4,    INTENT(IN)                            :: qww                        ! 
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: dispg(NSTAB)               ! 
+real,      INTENT(IN)                            :: qww
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: dispg(NSTAB)
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: radius                     ! 
-REAL*4,    INTENT(INOUT)                         :: xl                         ! 
-REAL*4,    INTENT(INOUT)                         :: onder                      ! 
+real,      INTENT(INOUT)                         :: radius
+real,      INTENT(INOUT)                         :: xl
+real,      INTENT(INOUT)                         :: onder
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record 
 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: htot                       ! plume height, including plume descent due to heavy particles [m]
+real,      INTENT(OUT)                           :: htot                       ! plume height, including plume descent due to heavy particles [m]
                                                                                ! htot = htt - pldaling 
-REAL*4,    INTENT(OUT)                           :: grof                       ! 
-REAL*4,    INTENT(OUT)                           :: c                          ! 
-REAL*4,    INTENT(OUT)                           :: sigz                       ! 
-REAL*4,    INTENT(OUT)                           :: ueff                       ! wind speed at effective transport height heff; 
+real,      INTENT(OUT)                           :: grof
+real,      INTENT(OUT)                           :: c
+real,      INTENT(OUT)                           :: sigz
+real,      INTENT(OUT)                           :: ueff                       ! wind speed at effective transport height heff;
                                                                                ! for short distances heff = plume height;
                                                                                ! for large distances heff = 1/2 mixing height;
                                                                                ! heff is interpolated for intermediate distances.
 
-REAL*4,    INTENT(OUT)                           :: virty                      ! 
-REAL*4,    INTENT(OUT)                           :: ccc                        ! 
+real,      INTENT(OUT)                           :: virty
+real,      INTENT(OUT)                           :: ccc
 
 ! LOCAL VARIABLES
-REAL*4                                           :: ff                         ! 
-REAL*4                                           :: pldaling                   ! 
+real                                             :: ff
+real                                             :: pldaling
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_conc_rek.f90
+++ b/ops_conc_rek.f90
@@ -55,60 +55,60 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_conc_rek')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: ueff                       ! 
-REAL*4,    INTENT(IN)                            :: qbpri                      ! 
+real,      INTENT(IN)                            :: ueff
+real,      INTENT(IN)                            :: qbpri
 LOGICAL,   INTENT(IN)                            :: isec                       ! 
-REAL*4,    INTENT(IN)                            :: rcsec                      ! 
-REAL*4,    INTENT(IN)                            :: routsec                    ! in-cloud scavenging ratio for secondary component
+real,      INTENT(IN)                            :: rcsec
+real,      INTENT(IN)                            :: routsec                    ! in-cloud scavenging ratio for secondary component
                                                                                ! (rout << rain-out = in-cloud) [-]
-REAL*4,    INTENT(IN)                            :: ccc                        ! 
-REAL*4,    INTENT(IN)                            :: amol1                      ! 
-REAL*4,    INTENT(IN)                            :: amol2                      ! 
-REAL*4,    INTENT(IN)                            :: sigz                       ! 
-REAL*4,    INTENT(IN)                            :: utr                        ! average wind speed over the trajectory (m/s)
-REAL*4,    INTENT(IN)                            :: rc_sec_rcp                 ! 
-REAL*4,    INTENT(IN)                            :: ra4_rcp                    ! 
-REAL*4,    INTENT(IN)                            :: ra50_rcp                   ! 
-REAL*4,    INTENT(IN)                            :: rb_rcp                     ! 
-REAL*4,    INTENT(IN)                            :: amol21                     ! 
-REAL*4,    INTENT(IN)                            :: ugmoldep                   ! 
-REAL*4,    INTENT(IN)                            :: cch                        ! 
-REAL*4,    INTENT(IN)                            :: cgt                        ! 
-REAL*4,    INTENT(IN)                            :: cgt_z                      ! height dependent cgt
-REAL*4,    INTENT(IN)                            :: grof                       ! 
-REAL*4,    INTENT(IN)                            :: percvk                     ! 
-REAL*4,    INTENT(IN)                            :: onder                      ! 
-REAL*4,    INTENT(IN)                            :: regenk                     ! 
-REAL*4,    INTENT(IN)                            :: virty                      ! 
-REAL*4,    INTENT(IN)                            :: ri                         ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: pcoef                      ! 
-REAL*4,    INTENT(IN)                            :: rkc                        ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: vnatpri                    ! 
-REAL*4,    INTENT(IN)                            :: vchem                      ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: xloc                       ! 
-REAL*4,    INTENT(IN)                            :: htot                       ! 
-REAL*4,    INTENT(IN)                            :: twt                        ! 
-REAL*4,    INTENT(IN)                            :: rb                         ! 
-REAL*4,    INTENT(IN)                            :: ra50                       ! 
-REAL*4,    INTENT(IN)                            :: xvghbr                     ! 
-REAL*4,    INTENT(IN)                            :: xvglbr                     ! 
-REAL*4,    INTENT(IN)                            :: grad                       ! 
-REAL*4,    INTENT(IN)                            :: frac                       ! fraction of this grid cell that is relevant
-REAL*4,    INTENT(IN)                            :: ra50tra                    ! 
-REAL*4,    INTENT(IN)                            :: rb_tra                     ! 
-REAL*4,    INTENT(IN)                            :: rclocal                    ! 
-REAL*4,    INTENT(IN)                            :: vgpart                     ! 
-REAL*4,    INTENT(IN)                            :: buildingFact               ! Building Effect interpolated from building table
+real,      INTENT(IN)                            :: ccc
+real,      INTENT(IN)                            :: amol1
+real,      INTENT(IN)                            :: amol2
+real,      INTENT(IN)                            :: sigz
+real,      INTENT(IN)                            :: utr                        ! average wind speed over the trajectory (m/s)
+real,      INTENT(IN)                            :: rc_sec_rcp
+real,      INTENT(IN)                            :: ra4_rcp
+real,      INTENT(IN)                            :: ra50_rcp
+real,      INTENT(IN)                            :: rb_rcp
+real,      INTENT(IN)                            :: amol21
+real,      INTENT(IN)                            :: ugmoldep
+real,      INTENT(IN)                            :: cch
+real,      INTENT(IN)                            :: cgt
+real,      INTENT(IN)                            :: cgt_z                      ! height dependent cgt
+real,      INTENT(IN)                            :: grof
+real,      INTENT(IN)                            :: percvk
+real,      INTENT(IN)                            :: onder
+real,      INTENT(IN)                            :: regenk
+real,      INTENT(IN)                            :: virty
+real,      INTENT(IN)                            :: ri
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: pcoef
+real,      INTENT(IN)                            :: rkc
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: vnatpri
+real,      INTENT(IN)                            :: vchem
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: xloc
+real,      INTENT(IN)                            :: htot
+real,      INTENT(IN)                            :: twt
+real,      INTENT(IN)                            :: rb
+real,      INTENT(IN)                            :: ra50
+real,      INTENT(IN)                            :: xvghbr
+real,      INTENT(IN)                            :: xvglbr
+real,      INTENT(IN)                            :: grad
+real,      INTENT(IN)                            :: frac                       ! fraction of this grid cell that is relevant
+real,      INTENT(IN)                            :: ra50tra
+real,      INTENT(IN)                            :: rb_tra
+real,      INTENT(IN)                            :: rclocal
+real,      INTENT(IN)                            :: vgpart
+real,      INTENT(IN)                            :: buildingFact               ! Building Effect interpolated from building table
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: cdn                        ! 
-REAL*4,    INTENT(INOUT)                         :: cq2                        ! 
-REAL*4,    INTENT(INOUT)                         :: c                          ! 
+real,      INTENT(INOUT)                         :: cdn
+real,      INTENT(INOUT)                         :: cq2
+real,      INTENT(INOUT)                         :: c
 DOUBLE PRECISION, INTENT(INOUT)                  :: sdrypri                    ! 
 DOUBLE PRECISION, INTENT(INOUT)                  :: sdrysec                    ! 
 DOUBLE PRECISION, INTENT(INOUT)                  :: snatsec                    ! 
@@ -124,31 +124,31 @@ DOUBLE PRECISION, INTENT(INOUT)                  :: drydep                     !
 DOUBLE PRECISION, INTENT(INOUT)                  :: wetdep                     ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: qsec                       ! 
-REAL*4,    INTENT(OUT)                           :: consec                     ! 
-REAL*4,    INTENT(OUT)                           :: pr                         ! 
-REAL*4,    INTENT(OUT)                           :: vg50trans                  ! 
+real,      INTENT(OUT)                           :: qsec
+real,      INTENT(OUT)                           :: consec
+real,      INTENT(OUT)                           :: pr
+real,      INTENT(OUT)                           :: vg50trans
 
 ! LOCAL VARIABLES
-REAL*4                                           :: qpri_depl                  ! depleted source strength = integrated mass flux [g/s]
-REAL*4                                           :: vv                         ! 
-REAL*4                                           :: drypri                     ! 
-REAL*4                                           :: ddrup                      ! 
-REAL*4                                           :: vdrup                      ! 
-REAL*4                                           :: umid                       ! 
-REAL*4                                           :: virnat                     ! 
-REAL*4                                           :: dn                         ! 
-REAL*4                                           :: dnatpri                    ! 
-REAL*4                                           :: xvg                        ! factor not used; xvg = 1
-REAL*4                                           :: cgtsec                     ! 
-REAL*4                                           :: vgsec                      ! 
-REAL*4                                           :: vg_sec_rcp                 ! 
-REAL*4                                           :: vnatsec                    ! 
-REAL*4                                           :: drysec                     ! 
-REAL*4                                           :: dnatsec                    ! 
-REAL*4                                           :: vg4lok                     ! 
-REAL*4                                           :: c_z                        ! bewaren van de hoogte afhankelijke c
-REAL*4                                           :: xg
+real                                             :: qpri_depl                  ! depleted source strength = integrated mass flux [g/s]
+real                                             :: vv
+real                                             :: drypri
+real                                             :: ddrup
+real                                             :: vdrup
+real                                             :: umid
+real                                             :: virnat
+real                                             :: dn
+real                                             :: dnatpri
+real                                             :: xvg                        ! factor not used; xvg = 1
+real                                             :: cgtsec
+real                                             :: vgsec
+real                                             :: vg_sec_rcp
+real                                             :: vnatsec
+real                                             :: drysec
+real                                             :: dnatsec
+real                                             :: vg4lok
+real                                             :: c_z                        ! bewaren van de hoogte afhankelijke c
+real                                             :: xg
 
 
 ! SUBROUTINE AND FUNCTION CALLS

--- a/ops_conltexp.f90
+++ b/ops_conltexp.f90
@@ -57,69 +57,69 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_conltexp')
 
 ! CONSTANTS
-REAL*4                                           :: ZWCOR(NSTAB)               ! correctie voor vallende bronnen
-REAL*4                                           :: PICON                      ! = fac/[pi * sqrt(2*pi)], fac = conversion factor g -> ug; fac = 1e6
-REAL*4                                           :: PS                         ! = fac/(2*pi), fac = conversion factor g -> ug; fac = 1e6
+real                                             :: ZWCOR(NSTAB)               ! correctie voor vallende bronnen
+real                                             :: PICON                      ! = fac/[pi * sqrt(2*pi)], fac = conversion factor g -> ug; fac = 1e6
+real                                             :: PS                         ! = fac/(2*pi), fac = conversion factor g -> ug; fac = 1e6
 
 PARAMETER  (PICON = 126987.)
 PARAMETER  (PS    = 159155.)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: rond                       ! 
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov lengte
-REAL*4,    INTENT(IN)                            :: qbron                      ! 
-REAL*4,    INTENT(IN)                            :: szopp                      ! initial vertical dispersion of source
-REAL*4,    INTENT(IN)                            :: uster                      ! frictiesnelheid
-REAL*4,    INTENT(IN)                            :: z0                         ! ruwheidslengte (m)
-REAL*4,    INTENT(IN)                            :: htt                        ! 
-REAL*4,    INTENT(IN)                            :: onder                      ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: pcoef                      ! 
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov lengte
+real,      INTENT(IN)                            :: qbron
+real,      INTENT(IN)                            :: szopp                      ! initial vertical dispersion of source
+real,      INTENT(IN)                            :: uster                      ! frictiesnelheid
+real,      INTENT(IN)                            :: z0                         ! ruwheidslengte (m)
+real,      INTENT(IN)                            :: htt
+real,      INTENT(IN)                            :: onder
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: pcoef
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: grof                       ! 
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: grof
 INTEGER*4, INTENT(IN)                            :: iwd                        ! 
-REAL*4,    INTENT(IN)                            :: qww                        ! 
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: dispg(NSTAB)               ! 
+real,      INTENT(IN)                            :: qww
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: dispg(NSTAB)
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: radius                     ! 
-REAL*4,    INTENT(INOUT)                         :: htot                       ! 
+real,      INTENT(INOUT)                         :: radius
+real,      INTENT(INOUT)                         :: htot
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record 
 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: c                          ! long-term concentation at receptor at z = 0; excluding removal processes
-REAL*4,    INTENT(OUT)                           :: sigz                       ! 
-REAL*4,    INTENT(OUT)                           :: ueff                       ! wind speed at effective transport height heff; 
+real,      INTENT(OUT)                           :: c                          ! long-term concentation at receptor at z = 0; excluding removal processes
+real,      INTENT(OUT)                           :: sigz
+real,      INTENT(OUT)                           :: ueff                       ! wind speed at effective transport height heff;
                                                                                ! for short distances heff = plume height;
                                                                                ! for large distances heff = 1/2 mixing height;
                                                                                ! heff is interpolated for intermediate distances.
-REAL*4,    INTENT(OUT)                           :: xl                         ! 
-REAL*4,    INTENT(OUT)                           :: virty                      ! 
+real,      INTENT(OUT)                           :: xl
+real,      INTENT(OUT)                           :: virty
 
 ! LOCAL VARIABLES
-REAL*4                                           :: a                          ! reflection term source-surface-mixing height-surface
-REAL*4                                           :: b                          ! reflection term source-mixing height-surface
-REAL*4                                           :: cls                        ! 
-REAL*4                                           :: disp                       ! 
-REAL*4                                           :: f                          ! 
-REAL*4                                           :: f1                         ! 
-REAL*4                                           :: f2                         ! 
-REAL*4                                           :: h                          ! 
-REAL*4                                           :: hf                         ! effective transport height [m]
-REAL*4                                           :: pld                        ! pluimdaling
-REAL*4                                           :: pp                         ! 
-REAL*4                                           :: qq                         ! 
-REAL*4                                           :: rr                         ! 
-REAL*4                                           :: sz                         ! 
-REAL*4                                           :: tl                         ! 
-REAL*4                                           :: u1                         ! 
-REAL*4                                           :: utl                        ! 
+real                                             :: a                          ! reflection term source-surface-mixing height-surface
+real                                             :: b                          ! reflection term source-mixing height-surface
+real                                             :: cls
+real                                             :: disp
+real                                             :: f
+real                                             :: f1
+real                                             :: f2
+real                                             :: h
+real                                             :: hf                         ! effective transport height [m]
+real                                             :: pld                        ! pluimdaling
+real                                             :: pp
+real                                             :: qq
+real                                             :: rr
+real                                             :: sz
+real                                             :: tl
+real                                             :: u1
+real                                             :: utl
 
 ! FUNCTIONS
-REAL*4                                           :: ops_virtdist               ! 
+real                                             :: ops_virtdist
 
 !DATA
 DATA ZWCOR/1.2, 1.1, 0.8, 0.6, 0.75, 0.6/
@@ -397,38 +397,38 @@ PARAMETER    (ROUTINENAAM = 'par_oppbr')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: rond                       ! 
 INTEGER*4, INTENT(IN)                            :: iwd                        ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
+real,      INTENT(IN)                            :: disx
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: disp                       ! 
-REAL*4,    INTENT(IN)                            :: htt                        ! 
-REAL*4,    INTENT(IN)                            :: grof                       ! 
-REAL*4,    INTENT(IN)                            :: dispg(NSTAB)               ! 
-REAL*4,    INTENT(IN)                            :: zwcor(NSTAB)               ! 
+real,      INTENT(IN)                            :: disp
+real,      INTENT(IN)                            :: htt
+real,      INTENT(IN)                            :: grof
+real,      INTENT(IN)                            :: dispg(NSTAB)
+real,      INTENT(IN)                            :: zwcor(NSTAB)
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: radius                     ! 
-REAL*4,    INTENT(INOUT)                         :: sz                         ! 
+real,      INTENT(INOUT)                         :: radius
+real,      INTENT(INOUT)                         :: sz
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: virty                      ! 
-REAL*4,    INTENT(OUT)                           :: rr                         ! 
-REAL*4,    INTENT(OUT)                           :: sigz                       ! 
-REAL*4,    INTENT(OUT)                           :: pld                        ! 
-REAL*4,    INTENT(OUT)                           :: htot                       ! 
+real,      INTENT(OUT)                           :: virty
+real,      INTENT(OUT)                           :: rr
+real,      INTENT(OUT)                           :: sigz
+real,      INTENT(OUT)                           :: pld
+real,      INTENT(OUT)                           :: htot
 
 ! LOCAL VARIABLES
-REAL*4                                           :: cr                         ! 
-REAL*4                                           :: radr                       ! 
-REAL*4                                           :: dx                         ! 
-REAL*4                                           :: dy                         ! 
-REAL*4                                           :: sta1                         ! 
-REAL*4                                           :: sta2                         ! 
-REAL*4                                           :: s1                         ! 
-REAL*4                                           :: s2                         ! 
-REAL*4                                           :: dsx                        ! 
+real                                             :: cr
+real                                             :: radr
+real                                             :: dx
+real                                             :: dy
+real                                             :: sta1
+real                                             :: sta2
+real                                             :: s1
+real                                             :: s2
+real                                             :: dsx
 
 ! FUNCTIONS
-REAL*4                                           :: ops_virtdist               ! 
+real                                             :: ops_virtdist
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -506,20 +506,20 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'par_puntbr')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: qww                        ! 
+real,      INTENT(IN)                            :: qww
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: disp                       ! 
-REAL*4,    INTENT(IN)                            :: htt                        ! 
-REAL*4,    INTENT(IN)                            :: htot                       ! 
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: dispg(NSTAB)               ! 
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: disp
+real,      INTENT(IN)                            :: htt
+real,      INTENT(IN)                            :: htot
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: dispg(NSTAB)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: sigz                       ! 
-REAL*4,    INTENT(OUT)                           :: hf                         ! 
-REAL*4,    INTENT(OUT)                           :: a                          ! 
-REAL*4,    INTENT(OUT)                           :: virty                      ! 
+real,      INTENT(OUT)                           :: sigz
+real,      INTENT(OUT)                           :: hf
+real,      INTENT(OUT)                           :: a
+real,      INTENT(OUT)                           :: virty
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_conltexp.f90
+++ b/ops_conltexp.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Compute long term concentration for a given source and source-receptor distance;

--- a/ops_convec.f90
+++ b/ops_convec.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77)
 ! DESCRIPTION        : This routine calculates sigmaz for convective cases according to Weil and Brower (1982) formally defined

--- a/ops_convec.f90
+++ b/ops_convec.f90
@@ -50,28 +50,28 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_convec')
 
 ! CONSTANTS
-REAL*4                                           :: K                          ! von Karmanconstante
+real                                             :: K                          ! von Karmanconstante
 PARAMETER   (K = 0.4)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z0                         ! roughness length (m)
-REAL*4,    INTENT(IN)                            :: zi                         ! mixing height (m)
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity (m)
-REAL*4,    INTENT(IN)                            :: h                          ! source height (including plume rise) (m)
-REAL*4,    INTENT(IN)                            :: x                          ! downwind distance  (m)
+real,      INTENT(IN)                            :: z0                         ! roughness length (m)
+real,      INTENT(IN)                            :: zi                         ! mixing height (m)
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
+real,      INTENT(IN)                            :: uster                      ! friction velocity (m)
+real,      INTENT(IN)                            :: h                          ! source height (including plume rise) (m)
+real,      INTENT(IN)                            :: x                          ! downwind distance  (m)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uh                         ! windspeed at representative plume height (m/s)
-REAL*4,    INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection 
+real,      INTENT(OUT)                           :: uh                         ! windspeed at representative plume height (m/s)
+real,      INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection
                                                                                ! at the top of the mixing layer and at the ground surface
-REAL*4,    INTENT(OUT)                           :: szc                        ! convective vertical dispersion coefficient (m)
+real,      INTENT(OUT)                           :: szc                        ! convective vertical dispersion coefficient (m)
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: last                       ! 
-REAL*4                                           :: s                          ! 
-REAL*4                                           :: wster                      ! 
-REAL*4                                           :: xs                         ! 
+real                                             :: s
+real                                             :: wster
+real                                             :: xs
 LOGICAL                                          :: finished                   ! 
 
 ! SCCS-ID VARIABLES

--- a/ops_depoparexp.f90
+++ b/ops_depoparexp.f90
@@ -79,123 +79,123 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_depoparexp')
 
 ! CONSTANTS
-REAL*4                                           :: RCDEEL(NPARTCLASS)         ! waarden van rc per deeltjesklasse
-REAL*4                                           :: RDS(NSTAB)                 ! grenslaagweerstand per stab. klasse
-REAL*4                                           :: RORATIO(NPARTCLASS)        ! (geschatte) waarden scavenging ratio per deeltjesklasse
-REAL*4                                           :: VGDEEL(NPARTCLASS)         ! 
-REAL*4                                           :: RA4S(NSTAB)                ! 
+real                                             :: RCDEEL(NPARTCLASS)         ! waarden van rc per deeltjesklasse
+real                                             :: RDS(NSTAB)                 ! grenslaagweerstand per stab. klasse
+real                                             :: RORATIO(NPARTCLASS)        ! (geschatte) waarden scavenging ratio per deeltjesklasse
+real                                             :: VGDEEL(NPARTCLASS)
+real                                             :: RA4S(NSTAB)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: kdeel                      ! 
-REAL*4,    INTENT(IN)                            :: c                          ! 
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov lengte
-REAL*4,    INTENT(IN)                            :: qbstf                      ! source strength current source (for current particle class)
-REAL*4,    INTENT(IN)                            :: ra4_rcp                    ! ra at receptor (4m)
-REAL*4,    INTENT(IN)                            :: ra50_rcp                   ! ra at receptor (50m)
-REAL*4,    INTENT(IN)                            :: raz_rcp                    ! height dependent ra on receptor
-REAL*4,    INTENT(IN)                            :: rb_rcp                     ! 
-REAL*4,    INTENT(IN)                            :: sigz                       ! 
-REAL*4,    INTENT(IN)                            :: ueff                       ! wind speed at effective transport height heff; 
+real,      INTENT(IN)                            :: c
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov lengte
+real,      INTENT(IN)                            :: qbstf                      ! source strength current source (for current particle class)
+real,      INTENT(IN)                            :: ra4_rcp                    ! ra at receptor (4m)
+real,      INTENT(IN)                            :: ra50_rcp                   ! ra at receptor (50m)
+real,      INTENT(IN)                            :: raz_rcp                    ! height dependent ra on receptor
+real,      INTENT(IN)                            :: rb_rcp
+real,      INTENT(IN)                            :: sigz
+real,      INTENT(IN)                            :: ueff                       ! wind speed at effective transport height heff;
                                                                                ! for short distances heff = plume height;
                                                                                ! for large distances heff = 1/2 mixing height;
                                                                                ! heff is interpolated for intermediate distances.
-REAL*4,    INTENT(IN)                            :: uster
-REAL*4,    INTENT(IN)                            :: z0
-REAL*4,    INTENT(IN)                            :: virty                      ! 
+real,      INTENT(IN)                            :: uster
+real,      INTENT(IN)                            :: z0
+real,      INTENT(IN)                            :: virty
 LOGICAL,   INTENT(IN)                            :: gasv                       ! 
 INTEGER*4, INTENT(IN)                            :: itra                       ! 
-REAL*4,    INTENT(IN)                            :: rb                         ! 
-REAL*4,    INTENT(IN)                            :: ra4                        ! 
+real,      INTENT(IN)                            :: rb
+real,      INTENT(IN)                            :: ra4
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: grof                       ! 
-REAL*4,    INTENT(IN)                            :: ra50                       ! 
-REAL*4,    INTENT(IN)                            :: xvghbr                     ! 
-REAL*4,    INTENT(IN)                            :: xvglbr                     ! 
-REAL*4,    INTENT(IN)                            :: regenk                     ! 
-REAL*4,    INTENT(IN)                            :: rint                       ! 
-REAL*4,    INTENT(IN)                            :: buil                       ! 
-REAL*4,    INTENT(IN)                            :: zf                         ! 
+real,      INTENT(IN)                            :: grof
+real,      INTENT(IN)                            :: ra50
+real,      INTENT(IN)                            :: xvghbr
+real,      INTENT(IN)                            :: xvglbr
+real,      INTENT(IN)                            :: regenk
+real,      INTENT(IN)                            :: rint
+real,      INTENT(IN)                            :: buil
+real,      INTENT(IN)                            :: zf
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
 INTEGER*4, INTENT(IN)                            :: iseiz                      ! 
 INTEGER*4, INTENT(IN)                            :: mb                         ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: onder                      ! 
-REAL*4,    INTENT(IN)                            :: dg                         ! 
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: onder
+real,      INTENT(IN)                            :: dg
 INTEGER*4, INTENT(IN)                            :: knatdeppar                 ! 
-REAL*4,    INTENT(IN)                            :: scavcoef                   ! 
+real,      INTENT(IN)                            :: scavcoef
 LOGICAL,   INTENT(IN)                            :: irev                       ! 
-REAL*4,    INTENT(IN)                            :: htt                        ! 
-REAL*4,    INTENT(IN)                            :: xloc                       ! 
-REAL*4,    INTENT(IN)                            :: xl100                      ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: pcoef                      ! 
-REAL*4,    INTENT(IN)                            :: vchem                      ! 
-REAL*4,    INTENT(IN)                            :: dispg(NSTAB)               ! 
-REAL*4,    INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: ol_src                     !
-REAL*4,    INTENT(IN)                            :: uster_src                  !
-REAL*4,    INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
-REAL*4,    INTENT(IN)                            :: ra4src                     !
-REAL*4,    INTENT(IN)                            :: rb_src                     !
-REAL*4,    INTENT(IN)                            :: ra50src                    !
-REAL*4,    INTENT(IN)                            :: ra4tra                     !
-REAL*4,    INTENT(IN)                            :: rb_tra                     !
-REAL*4,    INTENT(IN)                            :: ra50tra                    !
-REAL*4,    INTENT(IN)                            :: xm
-REAL*4,    INTENT(IN)                            :: ym
-REAL*4,    INTENT(IN)                            :: zm                         ! z-coordinate of receptor points (RDM)
+real,      INTENT(IN)                            :: htt
+real,      INTENT(IN)                            :: xloc
+real,      INTENT(IN)                            :: xl100
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: pcoef
+real,      INTENT(IN)                            :: vchem
+real,      INTENT(IN)                            :: dispg(NSTAB)
+real,      INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(IN)                            :: ol_src
+real,      INTENT(IN)                            :: uster_src
+real,      INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
+real,      INTENT(IN)                            :: ra4src
+real,      INTENT(IN)                            :: rb_src
+real,      INTENT(IN)                            :: ra50src
+real,      INTENT(IN)                            :: ra4tra
+real,      INTENT(IN)                            :: rb_tra
+real,      INTENT(IN)                            :: ra50tra
+real,      INTENT(IN)                            :: xm
+real,      INTENT(IN)                            :: ym
+real,      INTENT(IN)                            :: zm                         ! z-coordinate of receptor points (RDM)
 INTEGER*4, INTENT(IN)                            :: bx 
 INTEGER*4, INTENT(IN)                            :: by
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: rctra_0                    !
-REAL*4,    INTENT(INOUT)                         :: htot                       ! 
-REAL*4,    INTENT(INOUT)                         :: rcsrc                      !
+real,      INTENT(INOUT)                         :: rctra_0
+real,      INTENT(INOUT)                         :: htot
+real,      INTENT(INOUT)                         :: rcsrc
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: pr                         ! 
-REAL*4,    INTENT(OUT)                           :: twt                        ! 
-REAL*4,    INTENT(OUT)                           :: cratio                     ! 
-REAL*4,    INTENT(OUT)                           :: rc_rcp                     ! 
-REAL*4,    INTENT(OUT)                           :: grad                       ! 
-REAL*4,    INTENT(OUT)                           :: rc                         
-REAL*4,    INTENT(OUT)                           :: utr                        ! average wind speed over the trajectory (m/s)
-REAL*4,    INTENT(OUT)                           :: vg50_rcp                   ! 
-REAL*4,    INTENT(OUT)                           :: vgpart                     ! 
-REAL*4,    INTENT(OUT)                           :: routpri                    ! in-cloud scavenging ratio for primary component
+real,      INTENT(OUT)                           :: pr
+real,      INTENT(OUT)                           :: twt
+real,      INTENT(OUT)                           :: cratio
+real,      INTENT(OUT)                           :: rc_rcp
+real,      INTENT(OUT)                           :: grad
+real,      INTENT(OUT)                           :: rc
+real,      INTENT(OUT)                           :: utr                        ! average wind speed over the trajectory (m/s)
+real,      INTENT(OUT)                           :: vg50_rcp
+real,      INTENT(OUT)                           :: vgpart
+real,      INTENT(OUT)                           :: routpri                    ! in-cloud scavenging ratio for primary component
                                                                                ! (rout << rain-out = in-cloud) [-]
-REAL*4,    INTENT(OUT)                           :: vg50trans                  ! 
-REAL*4,    INTENT(OUT)                           :: rkc                        ! 
-REAL*4,    INTENT(OUT)                           :: ri                         ! 
-REAL*4,    INTENT(OUT)                           :: vnatpri                    ! wet deposition loss rate for primary components [%/h]
-REAL*4,    INTENT(OUT)                           :: cgt                        ! 
-REAL*4,    INTENT(OUT)                           :: cgt_z                      ! height dependent cgt
-REAL*4,    INTENT(OUT)                           :: cq2                        ! 
-REAL*4,    INTENT(OUT)                           :: cdn                        ! 
-REAL*4,    INTENT(OUT)                           :: cch                        ! 
+real,      INTENT(OUT)                           :: vg50trans
+real,      INTENT(OUT)                           :: rkc
+real,      INTENT(OUT)                           :: ri
+real,      INTENT(OUT)                           :: vnatpri                    ! wet deposition loss rate for primary components [%/h]
+real,      INTENT(OUT)                           :: cgt
+real,      INTENT(OUT)                           :: cgt_z                      ! height dependent cgt
+real,      INTENT(OUT)                           :: cq2
+real,      INTENT(OUT)                           :: cdn
+real,      INTENT(OUT)                           :: cch
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: flag                       ! stable meteo class and stack emitting above mixing layer 
-REAL*4                                           :: a                          ! 
-REAL*4                                           :: cq1                        ! 
-REAL*4                                           :: diameter                   ! 
-REAL*4                                           :: dxeff                      ! effective distance over which deposition takes place within an area source
-REAL*4                                           :: grad_z                     ! height dependent grad
-REAL*4                                           :: hf                         ! 
-REAL*4                                           :: p1                         ! 
-REAL*4                                           :: p2                         ! 
-REAL*4                                           :: pldaling                   ! 
-REAL*4                                           :: sigzr                      ! 
-REAL*4                                           :: ux0                        ! wind speed near source at plume height (m/s)
-REAL*4                                           :: uxr                        ! wind speed representative for plume over area source (m/s)
-REAL*4                                           :: ugem                       ! average wind speed depending on phase of plume development (m/s)
-REAL*4                                           :: vg0tra                     ! 
-REAL*4                                           :: vg50tra                    ! 
-REAL*4                                           :: xg                         ! 
-REAL*4                                           :: zu                         ! 
+real                                             :: a
+real                                             :: cq1
+real                                             :: diameter
+real                                             :: dxeff                      ! effective distance over which deposition takes place within an area source
+real                                             :: grad_z                     ! height dependent grad
+real                                             :: hf
+real                                             :: p1
+real                                             :: p2
+real                                             :: pldaling
+real                                             :: sigzr
+real                                             :: ux0                        ! wind speed near source at plume height (m/s)
+real                                             :: uxr                        ! wind speed representative for plume over area source (m/s)
+real                                             :: ugem                       ! average wind speed depending on phase of plume development (m/s)
+real                                             :: vg0tra
+real                                             :: vg50tra
+real                                             :: xg
+real                                             :: zu
 LOGICAL                                          :: ops_openlog                ! function for opening log file
 
 !
@@ -617,64 +617,64 @@ SUBROUTINE par_nat(regenk, rint, buil, zf, isek, iseiz, mb, disx, radius, diamet
                 &  knatdeppar, scavcoef, routpri, kdeel, irev, c, qbstf, virty, twt, pr, cratio, ri, a, vnatpri)
 
 ! CONSTANTS
-REAL*4                                           :: PS                         ! 
+real                                             :: PS
 PARAMETER   (PS    = 1.e6/(2.*PI))
-REAL*4                                           :: TWETZ(NSEK)                ! duration of rain shower in summer
-REAL*4                                           :: TWETW(NSEK)                ! duration of rain shower in winter
-REAL*4                                           :: RIW(NSEK)                  ! rain intensity winter
-REAL*4                                           :: RIZ(NSEK)                  ! rain intensity summer
-REAL*4                                           :: CMND(NMONTH)               ! monthly correction shower duration
-REAL*4                                           :: EPSILON(NPARTCLASS)        ! 
+real                                             :: TWETZ(NSEK)                ! duration of rain shower in summer
+real                                             :: TWETW(NSEK)                ! duration of rain shower in winter
+real                                             :: RIW(NSEK)                  ! rain intensity winter
+real                                             :: RIZ(NSEK)                  ! rain intensity summer
+real                                             :: CMND(NMONTH)               ! monthly correction shower duration
+real                                             :: EPSILON(NPARTCLASS)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: regenk                     ! 
-REAL*4,    INTENT(IN)                            :: rint                       ! 
-REAL*4,    INTENT(IN)                            :: buil                       ! 
-REAL*4,    INTENT(IN)                            :: zf                         ! 
+real,      INTENT(IN)                            :: regenk
+real,      INTENT(IN)                            :: rint
+real,      INTENT(IN)                            :: buil
+real,      INTENT(IN)                            :: zf
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
 INTEGER*4, INTENT(IN)                            :: iseiz                      ! 
 INTEGER*4, INTENT(IN)                            :: mb                         ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: diameter                   ! 
-REAL*4,    INTENT(IN)                            :: ueff                       ! wind speed at effective transport height heff; 
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: diameter
+real,      INTENT(IN)                            :: ueff                       ! wind speed at effective transport height heff;
                                                                                ! for short distances heff = plume height;
                                                                                ! for large distances heff = 1/2 mixing height;
                                                                                ! heff is interpolated for intermediate distances.
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: onder                      ! 
-REAL*4,    INTENT(IN)                            :: sigz                       ! 
-REAL*4,    INTENT(IN)                            :: htot                       ! 
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: onder
+real,      INTENT(IN)                            :: sigz
+real,      INTENT(IN)                            :: htot
 LOGICAL,   INTENT(IN)                            :: gasv                       ! 
-REAL*4,    INTENT(IN)                            :: dg                         ! 
+real,      INTENT(IN)                            :: dg
 INTEGER*4, INTENT(IN)                            :: knatdeppar                 ! 
-REAL*4,    INTENT(IN)                            :: scavcoef                   ! 
-REAL*4,    INTENT(IN)                            :: routpri                    ! in-cloud scavenging ratio for primary component
+real,      INTENT(IN)                            :: scavcoef
+real,      INTENT(IN)                            :: routpri                    ! in-cloud scavenging ratio for primary component
                                                                                ! (rout << rain-out = in-cloud) [-]
 INTEGER*4, INTENT(IN)                            :: kdeel                      ! 
 LOGICAL,   INTENT(IN)                            :: irev                       ! 
-REAL*4,    INTENT(IN)                            :: c                          ! 
-REAL*4,    INTENT(IN)                            :: qbstf                      ! 
-REAL*4,    INTENT(IN)                            :: virty                      ! 
+real,      INTENT(IN)                            :: c
+real,      INTENT(IN)                            :: qbstf
+real,      INTENT(IN)                            :: virty
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: twt                        ! 
-REAL*4,    INTENT(OUT)                           :: pr                         ! 
-REAL*4,    INTENT(OUT)                           :: cratio                     ! 
-REAL*4,    INTENT(OUT)                           :: ri                         ! 
-REAL*4,    INTENT(OUT)                           :: a                          ! 
-REAL*4,    INTENT(OUT)                           :: vnatpri                    ! wet deposition loss rate for primary components [%/h]
+real,      INTENT(OUT)                           :: twt
+real,      INTENT(OUT)                           :: pr
+real,      INTENT(OUT)                           :: cratio
+real,      INTENT(OUT)                           :: ri
+real,      INTENT(OUT)                           :: a
+real,      INTENT(OUT)                           :: vnatpri                    ! wet deposition loss rate for primary components [%/h]
 
 ! LOCAL VARIABLES
-REAL*4                                           :: twet                       ! 
-REAL*4                                           :: treis                      ! 
-REAL*4                                           :: h                          ! thickness over which wet deposition takes place [m]
-REAL*4                                           :: hl                         ! 
-REAL*4                                           :: vnatrain                   ! wet deposition loss rate for rainout (in-cloud) [%/h]
-REAL*4                                           :: epsi                       ! 
-REAL*4                                           :: beta                       ! 
-REAL*4                                           :: lambda0                    ! 
-REAL*4                                           :: vnatwash                   ! wet deposition loss rate for washout (below-cloud) [%/h]
+real                                             :: twet
+real                                             :: treis
+real                                             :: h                          ! thickness over which wet deposition takes place [m]
+real                                             :: hl
+real                                             :: vnatrain                   ! wet deposition loss rate for rainout (in-cloud) [%/h]
+real                                             :: epsi
+real                                             :: beta
+real                                             :: lambda0
+real                                             :: vnatwash                   ! wet deposition loss rate for washout (below-cloud) [%/h]
 
 ! DATA figure 4.1 OPS-report (depends on particle class) and
 ! Slinn W.G.N (1983) Predictions for particle deposition to vegetative surfaces. Atmospheric Environment 16, 1785-1794.

--- a/ops_depoparexp.f90
+++ b/ops_depoparexp.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Get parameters needed for dry deposition, wet deposition and chemical conversion.
@@ -607,7 +610,7 @@ CONTAINS
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE         : par_nat
 ! DESCRIPTION        : Compute rain intensity and the wet deposition loss rate for primary components vnatpri
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! SYSTEM DEPENDENCIES: NON-ANSI F77
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE par_nat(regenk, rint, buil, zf, isek, iseiz, mb, disx, radius, diameter, ueff, xl, onder, sigz, htot, gasv, dg,      &
@@ -721,7 +724,7 @@ IF (regenk .GT. (0. + EPS_DELTA)) THEN
 !     Correction of twet [h] and ri [mm/h] for one month;
 !     iseiz = 4 -> one month in winter -> correction needed
 !
-      IF (iseiz .EQ. 4) THEN       ! IF (iseiz .EQ. 4 .OR. iseiz .EQ. 5) THEN   
+      IF (iseiz .EQ. 4) THEN       ! IF (iseiz .EQ. 4 .OR. iseiz .EQ. 5) THEN    FS
          twet = twet/CMND(mb)
          ri   = ri*CMND(mb)
       ENDIF

--- a/ops_depos_rc.f90
+++ b/ops_depos_rc.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-F77/90
 ! USAGE              : %M%
@@ -36,7 +39,8 @@
 ! CALLED FUNCTIONS   : depac
 ! UPDATE HISTORY :
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_depos_rc(icm, iseiz, mb, gym ,temp_C, uster, glrad, hum, nwet, ratns, catm, c_ave_prev, lu_per, ra, rb, rc_eff_pos, rc_eff)
+SUBROUTINE ops_depos_rc(icm, iseiz, mb, gym ,temp_C, uster, glrad, hum, nwet, ratns, catm, c_ave_prev_nh3, c_ave_prev_so2, &
+                      & lu_per, ra, rb, rc_eff_pos, rc_eff)
 
 USE m_commonconst
 USE m_depac318
@@ -59,7 +63,8 @@ REAL*4,    INTENT(IN)                            :: gym                        !
 REAL*4,    INTENT(IN)                            :: glrad                      ! 
 REAL*4,    INTENT(IN)                            :: ratns                      ! 
 REAL*4,    INTENT(IN)                            :: catm 
-REAL*4,    INTENT(IN)                            :: c_ave_prev
+REAL*4,    INTENT(IN)                            :: c_ave_prev_nh3
+REAL*4,    INTENT(IN)                            :: c_ave_prev_so2
 REAL*4,    INTENT(IN)                            :: ra
 REAL*4,    INTENT(IN)                            :: rb
 REAL*4,    INTENT(IN)                            :: lu_per(NLU)                ! land use percentages for all land use classes
@@ -156,7 +161,7 @@ DO luclass = 1,NLU
 !           rc_eff_depac: effective Rc (includes effect of compensation point); rc_eff_depac depends on the value of Ra and Rb.
 !          
         CALL depac318(CNAME(icm,5), day_of_year, gym ,temp_C, uster, glrad, sinphi, hum, nwet, luclass, nint(ratns),   & 
-                    & rc_tot, c_ave_prev, max(catm,catm_min), ccomp_tot, ra, rb, rc_eff_depac)
+                    & rc_tot, c_ave_prev_nh3, c_ave_prev_so2, max(catm,catm_min), ccomp_tot, ra, rb, rc_eff_depac)
 !
 !          Detect missing values and set default values
 !

--- a/ops_depos_rc.f90
+++ b/ops_depos_rc.f90
@@ -56,39 +56,39 @@ INTEGER*4, INTENT(IN)                            :: icm                        !
 INTEGER*4, INTENT(IN)                            :: iseiz                      ! 
 INTEGER*4, INTENT(IN)                            :: mb                         ! 
 INTEGER*4, INTENT(IN)                            :: nwet                       ! 
-REAL*4,    INTENT(IN)                            :: hum                        ! 
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity [m/s]
-REAL*4,    INTENT(IN)                            :: temp_C                     ! temperature at height zmet_T [C]
-REAL*4,    INTENT(IN)                            :: gym                        !
-REAL*4,    INTENT(IN)                            :: glrad                      ! 
-REAL*4,    INTENT(IN)                            :: ratns                      ! 
-REAL*4,    INTENT(IN)                            :: catm 
-REAL*4,    INTENT(IN)                            :: c_ave_prev_nh3
-REAL*4,    INTENT(IN)                            :: c_ave_prev_so2
-REAL*4,    INTENT(IN)                            :: ra
-REAL*4,    INTENT(IN)                            :: rb
-REAL*4,    INTENT(IN)                            :: lu_per(NLU)                ! land use percentages for all land use classes
+real,      INTENT(IN)                            :: hum
+real,      INTENT(IN)                            :: uster                      ! friction velocity [m/s]
+real,      INTENT(IN)                            :: temp_C                     ! temperature at height zmet_T [C]
+real,      INTENT(IN)                            :: gym
+real,      INTENT(IN)                            :: glrad
+real,      INTENT(IN)                            :: ratns
+real,      INTENT(IN)                            :: catm
+real,      INTENT(IN)                            :: c_ave_prev_nh3
+real,      INTENT(IN)                            :: c_ave_prev_so2
+real,      INTENT(IN)                            :: ra
+real,      INTENT(IN)                            :: rb
+real,      INTENT(IN)                            :: lu_per(NLU)                ! land use percentages for all land use classes
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: rc_eff_pos                 ! canopy resistance, no re-emission [s/m]  
-REAL*4,    INTENT(OUT)                           :: rc_eff                     ! canopy resistance, re-emission allowed [s/m];  
+real,      INTENT(OUT)                           :: rc_eff_pos                 ! canopy resistance, no re-emission [s/m]
+real,      INTENT(OUT)                           :: rc_eff                     ! canopy resistance, re-emission allowed [s/m];
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: day_of_year                ! 
 INTEGER*4                                        :: mnt                        ! 
 INTEGER*4, DIMENSION(2)                          :: mnt_select                 ! 
 INTEGER*4                                        :: luclass                    ! 
-REAL*4                                           :: som_vd_month               ! summed vd over representative months
-REAL*4                                           :: som_vd_eff_ave             ! summed vd over land use classes (vd = 1/Ra + Rb + Rc_eff)
-REAL*4                                           :: som_vd_eff_ave_pos         ! summed vd over land use classes (vd = 1/Ra + Rb + Rc_eff_pos)
-REAL*4                                           :: telmaand 
-REAL*4                                           :: rc_eff_ave                 ! canopy resistance, re-emission allowed, averaged over representative months
-REAL*4                                           :: rc_eff_ave_pos             ! canopy resistance, no re-emission, averaged over representative months
-REAL*4                                           :: rc_tot
-REAL*4                                           :: sinphi
-REAL*4                                           :: ccomp_tot
-REAL*4, PARAMETER                                :: catm_min = 0.1E-05
-REAL*4                                           :: rc_eff_depac               ! canopy resistance from depac, re-emission allowed [s/m];  
+real                                             :: som_vd_month               ! summed vd over representative months
+real                                             :: som_vd_eff_ave             ! summed vd over land use classes (vd = 1/Ra + Rb + Rc_eff)
+real                                             :: som_vd_eff_ave_pos         ! summed vd over land use classes (vd = 1/Ra + Rb + Rc_eff_pos)
+real                                             :: telmaand
+real                                             :: rc_eff_ave                 ! canopy resistance, re-emission allowed, averaged over representative months
+real                                             :: rc_eff_ave_pos             ! canopy resistance, no re-emission, averaged over representative months
+real                                             :: rc_tot
+real                                             :: sinphi
+real                                             :: ccomp_tot
+real,   PARAMETER                                :: catm_min = 0.1E-05
+real                                             :: rc_eff_depac               ! canopy resistance from depac, re-emission allowed [s/m];
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_depu.f90
+++ b/ops_depu.f90
@@ -75,9 +75,9 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_depu')
 
 ! CONSTANTS
-REAL*4                                           :: P                          ! exponent (experimenteel bepaald)
-REAL*4                                           :: PR                         ! Prandtl number
-REAL*4                                           :: VONK                       ! Von Karman constante
+real                                             :: P                          ! exponent (experimenteel bepaald)
+real                                             :: PR                         ! Prandtl number
+real                                             :: VONK                       ! Von Karman constante
 
 PARAMETER   (VONK = 0.4  )
 PARAMETER   (P    = 2./3.)
@@ -85,21 +85,21 @@ PARAMETER   (PR   = 0.72 )
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: icnr                       ! component number for calculation of rb
-REAL*4,    INTENT(IN)                            :: z0                         ! surface roughness length in meters.
-REAL*4,    INTENT(IN)                            :: zra                        ! height for which deposition velocity is calculated (m)
-REAL*4,    INTENT(IN)                            :: d                          ! displacement height (usually 0.7 * vegetation height) (m)
-REAL*4,    INTENT(IN)                            :: rc                         ! canopy resistance in (s/m)
-REAL*4,    INTENT(IN)                            :: ol                         ! monin-obukhov length (m)
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity u* (m/s)
+real,      INTENT(IN)                            :: z0                         ! surface roughness length in meters.
+real,      INTENT(IN)                            :: zra                        ! height for which deposition velocity is calculated (m)
+real,      INTENT(IN)                            :: d                          ! displacement height (usually 0.7 * vegetation height) (m)
+real,      INTENT(IN)                            :: rc                         ! canopy resistance in (s/m)
+real,      INTENT(IN)                            :: ol                         ! monin-obukhov length (m)
+real,      INTENT(IN)                            :: uster                      ! friction velocity u* (m/s)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: vg                         ! depositin velocity at zra (m/s)
-REAL*4,    INTENT(OUT)                           :: ra                         ! aerodynamic resistance at zra (s/m)
-REAL*4,    INTENT(OUT)                           :: rb                         ! laminar layer resistance for component incr (s/m)
+real,      INTENT(OUT)                           :: vg                         ! depositin velocity at zra (m/s)
+real,      INTENT(OUT)                           :: ra                         ! aerodynamic resistance at zra (s/m)
+real,      INTENT(OUT)                           :: rb                         ! laminar layer resistance for component incr (s/m)
 
 ! LOCAL VARIABLES
-REAL*4                                           :: sc                         ! Schmidt number
-REAL*4                                           :: zru                        ! correction for displacement height
+real                                             :: sc                         ! Schmidt number
+real                                             :: zru                        ! correction for displacement height
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -161,13 +161,13 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'fpsih')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: eta                        ! stabiliteitsparameter z/l
+real,      INTENT(IN)                            :: eta                        ! stabiliteitsparameter z/l
 
 ! OUTPUT
 !     Return value
 !
 ! LOCAL VARIABLES
-REAL*4                                           :: y                          ! hulpvariabele bij de berekening
+real                                             :: y                          ! hulpvariabele bij de berekening
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_depu.f90
+++ b/ops_depu.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : J.W. mrt 1990/ Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! USAGE              :
@@ -147,7 +150,7 @@ CONTAINS
 ! DESCRIPTION        : Stability correction function in the surface layer temperature profile. The present model is an empirical
 !                      fit by Holtslag and De Bruin(1987) of data by Hicks (1976, Quart. J. R. Meteor. Soc., 102, 535-551).
 !                      See also Holtslag (1984, BLM, 29, 225-250)
-! AUTHOR             : ANTON BELJAARS (KNMI 25-5-87) / Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 !-------------------------------------------------------------------------------------------------------------------------------
 REAL FUNCTION fpsih(eta)
 

--- a/ops_gen_fnames.f90
+++ b/ops_gen_fnames.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -25,7 +28,7 @@
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
 ! USAGE              :
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-90
 ! DESCRIPTION        : Check existence and generate full file names of those files that have not been explicitly defined 

--- a/ops_gen_precip.f90
+++ b/ops_gen_precip.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE      : %B% - %S%
 ! DATE - TIME           : %E% - %U%
 ! WHAT                  : %W%:%E%
-! AUTHOR                : Hans van Jaarsveld
+! AUTHOR                : OPS-support   
 ! FIRM/INSTITUTE        : RIVM/LLO
 ! LANGUAGE              : FORTRAN-77/90
 ! DESCRIPTION           : Generate precipitation for receptors (sum of precipitation over

--- a/ops_gen_precip.f90
+++ b/ops_gen_precip.f90
@@ -53,12 +53,12 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_gen_precip')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: uurtot                      
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)  
-REAL*4,    INTENT(IN)                            :: trafst(NTRAJ)               
+real,      INTENT(IN)                            :: uurtot
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(IN)                            :: trafst(NTRAJ)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: precip                     ! array with precipitation per receptorpoint
+real,      INTENT(OUT)                           :: precip                     ! array with precipitation per receptorpoint
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
@@ -68,47 +68,47 @@ INTEGER*4                                        :: isekt                      !
 INTEGER*4                                        :: istab                      ! index of stability class
 INTEGER*4                                        :: iwd                        ! wind direction [degrees]
 INTEGER*4                                        :: itra                       ! dummy output of ops_statparexp
-REAL*4                                           :: hbron                      ! source height, dummy input for ops_statparexp
-REAL*4                                           :: disx                       ! distance source receptor, dummy input for ops_statparexp
-REAL*4                                           :: disxx                      ! dummy output of ops_statparexp
-REAL*4                                           :: radius                     ! source diameter, dummy input for ops_statparexp
-REAL*4                                           :: qww                        ! heat content of source, dummy input for ops_statparexp; 
+real                                             :: hbron                      ! source height, dummy input for ops_statparexp
+real                                             :: disx                       ! distance source receptor, dummy input for ops_statparexp
+real                                             :: disxx                      ! dummy output of ops_statparexp
+real                                             :: radius                     ! source diameter, dummy input for ops_statparexp
+real                                             :: qww                        ! heat content of source, dummy input for ops_statparexp;
                                                                                ! setting it to 0 prevents unnecessary computation of plume rise
                                                                                ! in ops_statparexp 
-REAL*4                                           :: V_stack                    ! here a dummy
-REAL*4                                           :: Ts_stack                   ! here a dummy         
+real                                             :: V_stack                    ! here a dummy
+real                                             :: Ts_stack                   ! here a dummy
 LOGICAL                                          :: emis_horizontal            ! here a dummy
-REAL*4                                           :: D_stack                    ! here a dummy
-REAL*4                                           :: vw10                       ! here a dummy
-REAL*4                                           :: aksek(12)                  ! here a dummy
-REAL*4                                           :: h0                         ! here a dummy
-REAL*4                                           :: hum                        ! here a dummy
-REAL*4                                           :: ol                         ! here a dummy
-REAL*4                                           :: shear                      ! here a dummy
-REAL*4                                           :: rcaerd                     ! here a dummy
-REAL*4                                           :: rcnh3d                     ! here a dummy
-REAL*4                                           :: rcno2d                     ! here a dummy
-REAL*4                                           :: temp_C                     ! here a dummy
-REAL*4                                           :: uster                      ! here a dummy
-REAL*4                                           :: pcoef                      ! here a dummy
-REAL*4                                           :: htot                       ! here a dummy
-REAL*4                                           :: htt                        ! here a dummy
-REAL*4                                           :: aant                       ! here a dummy
-REAL*4                                           :: xl                         ! here a dummy
-REAL*4                                           :: rb                         ! here a dummy
-REAL*4                                           :: ra4                        ! here a dummy
-REAL*4                                           :: ra50                       ! here a dummy
-REAL*4                                           :: xvglbr                     ! here a dummy
-REAL*4                                           :: xvghbr                     ! here a dummy
-REAL*4                                           :: xloc                       ! here a dummy
-REAL*4                                           :: xl100                      ! here a dummy
-REAL*4                                           :: rad                        ! here a dummy
-REAL*4                                           :: rcso2                      ! here a dummy
-REAL*4                                           :: coef_space_heating         ! here a dummy
-REAL*4                                           :: buil                       ! here a dummy
-REAL*4                                           :: regenk                     
-REAL*4                                           :: rint                       
-REAL*4                                           :: percvk                    
+real                                             :: D_stack                    ! here a dummy
+real                                             :: vw10                       ! here a dummy
+real                                             :: aksek(12)                  ! here a dummy
+real                                             :: h0                         ! here a dummy
+real                                             :: hum                        ! here a dummy
+real                                             :: ol                         ! here a dummy
+real                                             :: shear                      ! here a dummy
+real                                             :: rcaerd                     ! here a dummy
+real                                             :: rcnh3d                     ! here a dummy
+real                                             :: rcno2d                     ! here a dummy
+real                                             :: temp_C                     ! here a dummy
+real                                             :: uster                      ! here a dummy
+real                                             :: pcoef                      ! here a dummy
+real                                             :: htot                       ! here a dummy
+real                                             :: htt                        ! here a dummy
+real                                             :: aant                       ! here a dummy
+real                                             :: xl                         ! here a dummy
+real                                             :: rb                         ! here a dummy
+real                                             :: ra4                        ! here a dummy
+real                                             :: ra50                       ! here a dummy
+real                                             :: xvglbr                     ! here a dummy
+real                                             :: xvghbr                     ! here a dummy
+real                                             :: xloc                       ! here a dummy
+real                                             :: xl100                      ! here a dummy
+real                                             :: rad                        ! here a dummy
+real                                             :: rcso2                      ! here a dummy
+real                                             :: coef_space_heating         ! here a dummy
+real                                             :: buil                       ! here a dummy
+real                                             :: regenk
+real                                             :: rint
+real                                             :: percvk
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_gen_rcp.f90
+++ b/ops_gen_rcp.f90
@@ -57,12 +57,12 @@ PARAMETER    (ROUTINENAAM = 'ops_gen_rcp')
 INTEGER*4, INTENT(IN)                            :: spgrid                      
 LOGICAL,   INTENT(IN)                            :: igrens                      
 TYPE (TApsGridReal), INTENT(IN)                  :: masker                      
-REAL*4,    INTENT(IN)                            :: grid                        
+real,      INTENT(IN)                            :: grid
 INTEGER*4, INTENT(IN)                            :: nrcol                       
 INTEGER*4, INTENT(IN)                            :: nrrow                       
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptor points
-REAL*4,    INTENT(IN)                            :: xorg                        
-REAL*4,    INTENT(IN)                            :: yorg                        
+real,      INTENT(IN)                            :: xorg
+real,      INTENT(IN)                            :: yorg
 LOGICAL,   INTENT(IN)                            :: varz                      
 LOGICAL,   INTENT(IN)                            :: perc
 LOGICAL,   INTENT(IN)                            :: domlu                      
@@ -70,11 +70,11 @@ LOGICAL,   INTENT(IN)                            :: domlu
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: jump(nrrcp+1)              
 INTEGER*4, INTENT(OUT)                           :: lu_rcp_dom_all(nrrcp)               ! 
-REAL*4,    INTENT(OUT)                           :: xm(nrrcp)                  ! x-coordinates
-REAL*4,    INTENT(OUT)                           :: ym(nrrcp)                  ! y-coordinates
-REAL*4,    INTENT(OUT)                           :: zm(nrrcp)                  ! z-coordinates
-REAL*4,    INTENT(OUT)                           :: frac(nrrcp)                ! fraction of output cell on land surface
-REAL*4,    INTENT(OUT)                           :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
+real,      INTENT(OUT)                           :: xm(nrrcp)                  ! x-coordinates
+real,      INTENT(OUT)                           :: ym(nrrcp)                  ! y-coordinates
+real,      INTENT(OUT)                           :: zm(nrrcp)                  ! z-coordinates
+real,      INTENT(OUT)                           :: frac(nrrcp)                ! fraction of output cell on land surface
+real,      INTENT(OUT)                           :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
 INTEGER,   INTENT(OUT)                           :: lu_rcp_per_user_all(nrrcp,NLU) ! percentage of landuse for all receptors, used defined in receptor file
 CHARACTER*(*), INTENT(OUT)                       :: namrcp(nrrcp)              ! receptor names
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
@@ -92,13 +92,13 @@ INTEGER*4                                        :: nwords                     !
 INTEGER*4                                        :: check_nwords               ! number of words in string
 INTEGER*4                                        :: ix                         ! x coordinate of receptor point (read from file)                          
 INTEGER*4                                        :: iy                         ! y coordinate of receptor point (read from file) 
-REAL*4                                           :: zrcp                       ! z coordinate of receptor point (read from file) 
+real                                             :: zrcp                       ! z coordinate of receptor point (read from file)
 INTEGER*4                                        :: p                          ! receptor point number (dummy)
 INTEGER*4                                        :: ierr                       ! error status
-REAL*4                                           :: x_rcp                      ! x coordinate receptor point 
-REAL*4                                           :: y_rcp                      ! y coordinate receptor point 
-REAL*4                                           :: cellvalue                  ! value of masker grid cell at receptor point
-REAL*4                                           :: z0                         ! 
+real                                             :: x_rcp                      ! x coordinate receptor point
+real                                             :: y_rcp                      ! y coordinate receptor point
+real                                             :: cellvalue                  ! value of masker grid cell at receptor point
+real                                             :: z0
 INTEGER                                          :: lu_rcp_per_user(NLU)       ! percentages of landuse classes for this receptor
 LOGICAL                                          :: iscell                     ! whether point is inside masker grid
 CHARACTER*12                                     :: namrp                      ! name of receptor point

--- a/ops_gen_rcp.f90
+++ b/ops_gen_rcp.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Hans van Jaarsveld
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77, HP-F90)
 ! DESCRIPTION        : Generate coordinates of receptor points.

--- a/ops_get_arg.f90
+++ b/ops_get_arg.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE      : %B% - %S%
 ! DATE - TIME           : %E% - %U%
 ! WHAT                  : %W%:%E%
-! AUTHOR                :
+! AUTHOR                : OPS-support 
 ! FIRM/INSTITUTE        : RIVM/LLO
 ! LANGUAGE              : FORTRAN-77/90
 ! DESCRIPTION           : Retrieves the command line arguments and determines whether syntax is correct. If so, the complete

--- a/ops_get_dim.f90
+++ b/ops_get_dim.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME           : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Hans van Jaarsveld
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77, HP-F90)
 ! DESCRIPTION        : Calculation of dimension of receptor point grids.

--- a/ops_get_dim.f90
+++ b/ops_get_dim.f90
@@ -55,9 +55,9 @@ PARAMETER    (ROUTINENAAM = 'ops_get_dim')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: spgrid                      
 LOGICAL,   INTENT(IN)                            :: igrens                      
-REAL*4,    INTENT(IN)                            :: xc                          
-REAL*4,    INTENT(IN)                            :: yc                          
-REAL*4,    INTENT(IN)                            :: grid                        
+real,      INTENT(IN)                            :: xc
+real,      INTENT(IN)                            :: yc
+real,      INTENT(IN)                            :: grid
 
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT(INOUT)                         :: nrcol                      ! number of colums in grid
@@ -65,18 +65,18 @@ INTEGER*4, INTENT(INOUT)                         :: nrrow                      !
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: nrrcp                      ! number of receptor points
-REAL*4,    INTENT(OUT)                           :: xorg                       
-REAL*4,    INTENT(OUT)                           :: yorg                       
+real,      INTENT(OUT)                           :: xorg
+real,      INTENT(OUT)                           :: yorg
 TYPE (TApsGridReal), INTENT(OUT)                 :: masker                      
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
-REAL*4,    PARAMETER                             :: GRID_XSTART = 0.000        ! x-coordinate of left upper corner point of NL grid
-REAL*4,    PARAMETER                             :: GRID_YSTART = 620000.000   ! y-coordinate of left upper corner point of NL grid
-REAL*4,    PARAMETER                             :: NL_XLEFT    = 13562.623    !  
-REAL*4,    PARAMETER                             :: NL_XRIGHT   = 278018.313   ! 
-REAL*4,    PARAMETER                             :: NL_YUPPER   = 619122.750   ! 
-REAL*4,    PARAMETER                             :: NL_YLOWER   = 306838.813   ! 
+real,      PARAMETER                             :: GRID_XSTART = 0.000        ! x-coordinate of left upper corner point of NL grid
+real,      PARAMETER                             :: GRID_YSTART = 620000.000   ! y-coordinate of left upper corner point of NL grid
+real,      PARAMETER                             :: NL_XLEFT    = 13562.623
+real,      PARAMETER                             :: NL_XRIGHT   = 278018.313
+real,      PARAMETER                             :: NL_YUPPER   = 619122.750
+real,      PARAMETER                             :: NL_YLOWER   = 306838.813
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: i                          ! grid index                           
@@ -86,16 +86,16 @@ INTEGER*4                                        :: ix                         !
 INTEGER*4                                        :: iy                         ! y coordinate of receptor point (read from file) 
 INTEGER*4                                        :: p                          ! receptor point number (dummy)
 INTEGER*4                                        :: ierr                       ! error status
-REAL*4                                           :: lower                      
-REAL*4                                           :: xmax                       ! maximum x coordinate of receptor points
-REAL*4                                           :: xmax2                      
-REAL*4                                           :: xmin                       ! minimum x coordinate of receptor points
-REAL*4                                           :: ymax                       ! maximum y coordinate of receptor points
-REAL*4                                           :: ymax2                      
-REAL*4                                           :: ymin                       ! minimum y coordinate of receptor points
-REAL*4                                           :: x_rcp                      ! x coordinate receptor point 
-REAL*4                                           :: y_rcp                      ! y coordinate receptor point 
-REAL*4                                           :: cellvalue                  ! value of masker grid cell at receptor point
+real                                             :: lower
+real                                             :: xmax                       ! maximum x coordinate of receptor points
+real                                             :: xmax2
+real                                             :: xmin                       ! minimum x coordinate of receptor points
+real                                             :: ymax                       ! maximum y coordinate of receptor points
+real                                             :: ymax2
+real                                             :: ymin                       ! minimum y coordinate of receptor points
+real                                             :: x_rcp                      ! x coordinate receptor point
+real                                             :: y_rcp                      ! y coordinate receptor point
+real                                             :: cellvalue                  ! value of masker grid cell at receptor point
 LOGICAL                                          :: iscell                     ! whether point is inside masker grid
 CHARACTER*12                                     :: namrp                      ! name of receptor point
 
@@ -277,7 +277,7 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'gen_mask')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: grid                       
+real,      INTENT(IN)                            :: grid
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 TYPE (TApsGridReal), INTENT(OUT)                 :: maskergrid                 ! APS-grid with fraction of area inside NL for each grid cell
@@ -294,7 +294,7 @@ INTEGER*4                                        :: factor                     !
 INTEGER*4                                        :: land                       ! sum of 1's of base grid that lie inside a certain output mask grid cell
 INTEGER*4                                        :: nrcol                      ! number of columns in output mask grid
 INTEGER*4                                        :: nrrow                      ! number of rows in output mask grid
-REAL*4                                           :: outputres                  ! resolution of output mask grid [km]
+real                                             :: outputres                  ! resolution of output mask grid [km]
 CHARACTER*1                                      :: gridname                   ! denotes direction 'x' or 'y' where error occurred when checking
                                                                                ! for grid resolution conformity 
 

--- a/ops_getlu.f90
+++ b/ops_getlu.f90
@@ -48,8 +48,8 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'getlu')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: xr                         ! x-coordinate of point (RDM)
-REAL*4,    INTENT(IN)                            :: yr                         ! y-coordinate of point (RDM)
+real,      INTENT(IN)                            :: xr                         ! x-coordinate of point (RDM)
+real,      INTENT(IN)                            :: yr                         ! y-coordinate of point (RDM)
 TYPE (TApsGridInt), INTENT(IN)                   :: lugrid                     ! grid with landuse information
 
 ! SUBROUTINE ARGUMENTS - OUTPUT

--- a/ops_getlu.f90
+++ b/ops_getlu.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Retrieve dominant landuse class and percentages of each landuse class for a specific point.

--- a/ops_getlu_tra.f90
+++ b/ops_getlu_tra.f90
@@ -51,19 +51,19 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_getlu_tra')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: xr                         ! x-coordinate receptor (RDM)
-REAL*4,    INTENT(IN)                            :: yr                         ! y-coordinate receptor (RDM)
-REAL*4,    INTENT(IN)                            :: xb                         ! x-coordinate source (RDM) (b << "bron" = source)
-REAL*4,    INTENT(IN)                            :: yb                         ! y-coordinate source (RDM)
+real,      INTENT(IN)                            :: xr                         ! x-coordinate receptor (RDM)
+real,      INTENT(IN)                            :: yr                         ! y-coordinate receptor (RDM)
+real,      INTENT(IN)                            :: xb                         ! x-coordinate source (RDM) (b << "bron" = source)
+real,      INTENT(IN)                            :: yb                         ! y-coordinate source (RDM)
 TYPE (TApsGridInt), INTENT(IN)                   :: lugrid                     ! grid with land use class information (1: dominant land use, 2:NLU+1: percentages land use class)
 LOGICAL, INTENT(IN)                              :: domlu
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: lu_tra_per(NLU)            ! percentages of land use classes over trajectorie (over intermediate points)
+real,      INTENT(OUT)                           :: lu_tra_per(NLU)            ! percentages of land use classes over trajectorie (over intermediate points)
 
 ! LOCAL VARIABLES
-REAL*4                                           :: x                          ! x-coordinate intermediate point 
-REAL*4                                           :: y                          ! y-coordinate intermediate point
+real                                             :: x                          ! x-coordinate intermediate point
+real                                             :: y                          ! y-coordinate intermediate point
 INTEGER*4                                        :: lu_tra_per_sum(NLU)        ! sum of percentages of land use classes over trajectorie (over intermediate points)
 INTEGER*4                                        :: lu_tra_dom                 ! dominant land use class over trajectory source-receptor
 INTEGER*4                                        :: is                         ! index of intermediate point

--- a/ops_getlu_tra.f90
+++ b/ops_getlu_tra.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Compute dominant land use class and percentage of each land use

--- a/ops_getz0.f90
+++ b/ops_getz0.f90
@@ -49,21 +49,21 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_getz0')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: xr                         ! x-coordinate of point (RDM)
-REAL*4,    INTENT(IN)                            :: yr                         ! y-coordinate of point (RDM)
+real,      INTENT(IN)                            :: xr                         ! x-coordinate of point (RDM)
+real,      INTENT(IN)                            :: yr                         ! y-coordinate of point (RDM)
 TYPE (TApsGridInt), INTENT(IN)                   :: z0nlgrid                   ! map of roughness lengths in NL [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: z0eurgrid                  ! map of roughness lengths in Europe [m]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: z0                         ! value of roughnes length z0 [m]
+real,      INTENT(OUT)                           :: z0                         ! value of roughnes length z0 [m]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: i
 INTEGER*4                                        :: cellvalue                  ! value of z0 grid in grid cell
-REAL*4                                           :: gxr                        ! x-coordinate of point (lon-lat)
-REAL*4                                           :: gyr                        ! y-coordinate of point (lon-lat)
-REAL*4                                           :: lamx                       ! x-coordinate of point (lambert)
-REAL*4                                           :: lamy                       ! y-coordinate of point (lambert)
+real                                             :: gxr                        ! x-coordinate of point (lon-lat)
+real                                             :: gyr                        ! y-coordinate of point (lon-lat)
+real                                             :: lamx                       ! x-coordinate of point (lambert)
+real                                             :: lamy                       ! y-coordinate of point (lambert)
 LOGICAL                                          :: iscell                     ! whether point is inside z0 grid
 !-------------------------------------------------------------------------------------------------------------------------------
 !

--- a/ops_getz0.f90
+++ b/ops_getz0.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Retrieve roughness length z0 for a specific location.

--- a/ops_getz0_tra.f90
+++ b/ops_getz0_tra.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Compute average roughness length z0 over a trajectory.

--- a/ops_getz0_tra.f90
+++ b/ops_getz0_tra.f90
@@ -49,23 +49,23 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_getz0_tra')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: xr                         ! x coordinate receptor (RDM)
-REAL*4,    INTENT(IN)                            :: yr                         ! y coordinate receptor (RDM)
-REAL*4,    INTENT(IN)                            :: xb                         ! x coordinate source (RDM)
-REAL*4,    INTENT(IN)                            :: yb                         ! y coordinate source (RDM)
+real,      INTENT(IN)                            :: xr                         ! x coordinate receptor (RDM)
+real,      INTENT(IN)                            :: yr                         ! y coordinate receptor (RDM)
+real,      INTENT(IN)                            :: xb                         ! x coordinate source (RDM)
+real,      INTENT(IN)                            :: yb                         ! y coordinate source (RDM)
 TYPE (TApsGridInt), INTENT(IN)                   :: z0nlgrid                   ! map of roughness lengths in NL [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: z0eurgrid                  ! map of roughness lengths in Europe [m]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: z0_tra                     ! roughness length representative for trajectory [m]
+real,      INTENT(OUT)                           :: z0_tra                     ! roughness length representative for trajectory [m]
 
 ! LOCAL VARIABLES
-REAL*4                                           :: x                          ! x-coordinate intermediate point (RDM)
-REAL*4                                           :: y                          ! y-coordinate intermediate point (RDM)
-REAL*4                                           :: gx                         ! x-coordinate intermediate point (lon-lat)
-REAL*4                                           :: gy                         ! y-coordinate intermediate point (lon-lat)
-REAL*4                                           :: total                      ! summed total of log(1/z0) over intermediate points
-REAL*4                                           :: z0                         ! roughness length in intermediate point
+real                                             :: x                          ! x-coordinate intermediate point (RDM)
+real                                             :: y                          ! y-coordinate intermediate point (RDM)
+real                                             :: gx                         ! x-coordinate intermediate point (lon-lat)
+real                                             :: gy                         ! y-coordinate intermediate point (lon-lat)
+real                                             :: total                      ! summed total of log(1/z0) over intermediate points
+real                                             :: z0                         ! roughness length in intermediate point
 INTEGER*4                                        :: ns                         ! number of sub sectors between intermediate points
 INTEGER*4                                        :: i                          ! index of intermediate point
 !-------------------------------------------------------------------------------------------------------------------------------

--- a/ops_init.f90
+++ b/ops_init.f90
@@ -59,54 +59,53 @@ LOGICAL,   INTENT(IN)                            :: gasv
 LOGICAL,   INTENT(IN)                            :: idep   
 LOGICAL,   INTENT(IN)                            :: building_present1           ! at least one building is present in the source file   
 INTEGER*4, INTENT(IN)                            :: kdeppar                     
-REAL*4,    INTENT(IN)                            :: ddeppar                     
-REAL*4,    INTENT(IN)                            :: wdeppar                     
+real,      INTENT(IN)                            :: ddeppar
+real,      INTENT(IN)                            :: wdeppar
 INTEGER*4, INTENT(IN)                            :: ideh                        
 INTEGER*4, INTENT(IN)                            :: icm                         
 LOGICAL,   INTENT(IN)                            :: isec 
 INTEGER*4, INTENT(IN)                            :: nsubsec                      ! number of sub-secondary species                       
 INTEGER*4, INTENT(IN)                            :: iseiz                       
 INTEGER*4, INTENT(IN)                            :: mb                          
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) 
-REAL*4,    INTENT(IN)                            :: dverl(NHRBLOCKS,MAXDISTR)    
-REAL*4,    INTENT(IN)                            :: usdverl(NHRBLOCKS,MAXDISTR)  
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(IN)                            :: dverl(NHRBLOCKS,MAXDISTR)
+real,      INTENT(IN)                            :: usdverl(NHRBLOCKS,MAXDISTR)
 INTEGER*4, INTENT(IN)                            :: dv                          
 INTEGER*4, INTENT(IN)                            :: usdv                        
 
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT(INOUT)                         :: knatdeppar                  
-REAL*4,    INTENT(INOUT)                         :: amol2                       
+real,      INTENT(INOUT)                         :: amol2
 CHARACTER*(*), INTENT(INOUT)                     :: namco                       
-REAL*4,    INTENT(INOUT)                         :: amol1                       
-REAL*4,    INTENT(INOUT)                         :: dg                          
+real,      INTENT(INOUT)                         :: amol1
+real,      INTENT(INOUT)                         :: dg
 LOGICAL,   INTENT(INOUT)                         :: irev                        
-REAL*4,    INTENT(INOUT)                         :: vchemc                      
-REAL*4,    INTENT(INOUT)                         :: vchemv                      
-REAL*4,    INTENT(INOUT)                         :: emtrend                     
+real,      INTENT(INOUT)                         :: vchemc
+real,      INTENT(INOUT)                         :: vchemv
+real,      INTENT(INOUT)                         :: emtrend
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: rc                          
+real,      INTENT(OUT)                           :: rc
 CHARACTER*(*), INTENT(OUT)                       :: coneh                       
-REAL*4,    INTENT(OUT)                           :: amol21                      
+real,      INTENT(OUT)                           :: amol21
 CHARACTER*(*), INTENT(OUT)                       :: depeh                       
 CHARACTER*(*), INTENT(OUT)                       :: namsec                      
 CHARACTER*(*), INTENT(OUT)                       :: namse3                      
-REAL*4,    INTENT(OUT)                           :: ugmoldep                    
-REAL*4,    INTENT(OUT)                           :: scavcoef                    
-REAL*4,    INTENT(OUT)                           :: rcno                       
-REAL*4,    INTENT(OUT)                           :: rhno2                      
-REAL*4,    INTENT(OUT)                           :: rchno3                      
-REAL*4,    INTENT(OUT)                           :: routsec                    ! in-cloud scavenging ratio for secondary component
+real,      INTENT(OUT)                           :: ugmoldep
+real,      INTENT(OUT)                           :: scavcoef
+real,      INTENT(OUT)                           :: rcno
+real,      INTENT(OUT)                           :: rhno2
+real,      INTENT(OUT)                           :: rchno3
+real,      INTENT(OUT)                           :: routsec                    ! in-cloud scavenging ratio for secondary component
                                                                                ! (rout << rain-out = in-cloud) [-] 
-REAL*4,    INTENT(OUT)                           :: routpri                    ! in-cloud scavenging ratio for primary component
                                                                                ! (rout << rain-out = in-cloud) [-]
-REAL*4,    INTENT(OUT)                           :: conc_cf
-REAL*4,    INTENT(OUT)                           :: koh                         
-REAL*4,    INTENT(OUT)                           :: croutpri                   ! constant (initial) in-cloud scavenging ratio [-] for primary component                   
-REAL*4,    INTENT(OUT)                           :: somcsec                     
-REAL*4,    INTENT(OUT)                           :: ar                          
-REAL*4,    INTENT(OUT)                           :: rno2nox                     
-REAL*4,    INTENT(OUT)                           :: ecvl(NSTAB, NTRAJ, *)       
+real,      INTENT(OUT)                           :: routpri                    ! in-cloud scavenging ratio for primary component
+                                                                               ! (rout << rain-out = in-cloud) [-]
+real,      INTENT(OUT)                           :: conc_cf
+real,      INTENT(OUT)                           :: koh
+real,      INTENT(OUT)                           :: croutpri                   ! constant (initial) in-cloud scavenging ratio [-] for primary component
+real,      INTENT(OUT)                           :: somcsec
+real,      INTENT(OUT)                           :: ar
 CHARACTER*(*), INTENT(OUT)                       :: nam_subsec(nsubsec) 
 type(TbuildingEffect), INTENT(OUT)               :: buildingEffect             ! structure with building effect tables
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
@@ -119,8 +118,8 @@ INTEGER*4                                        :: ndv
 INTEGER*4                                        :: itraj                       
 INTEGER*4                                        :: istab                       
 INTEGER*4                                        :: iu                          
-REAL*4                                           :: vgmax                       
-REAL*4                                           :: som   
+real                                             :: vgmax
+real                                             :: som
 CHARACTER*512                                    :: line                      
 
 ! SCCS-ID VARIABLES

--- a/ops_init.f90
+++ b/ops_init.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE      : %B% - %S%
 ! DATE - TIME           : %E% - %U%
 ! WHAT                  : %W%:%E%
-! AUTHOR                :
+! AUTHOR                : OPS-support 
 ! FIRM/INSTITUTE        : RIVM/LLO
 ! LANGUAGE              : FORTRAN-77/90
 ! DESCRIPTION           : Initialisation of variables based on data from the control file and on meteo statistics.
@@ -36,10 +39,10 @@
 ! CALLED FUNCTIONS      : ops_masknew, amcgeo
 ! UPDATE HISTORY        :
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_init (gasv, idep, building_present1, kdeppar, knatdeppar, ddeppar, wdeppar, amol2, ideh, icm, isec, iseiz, mb, astat, dverl,       &
+SUBROUTINE ops_init (gasv, idep, building_present1, kdeppar, knatdeppar, ddeppar, wdeppar, amol2, ideh, icm, isec, nsubsec, iseiz, mb, astat, dverl,       &
                   &  usdverl, dv, usdv, namco, amol1, dg, irev, vchemc, vchemv, emtrend, rc, coneh, amol21, depeh, namsec,     &
                   &  namse3, ugmoldep, scavcoef, rcno, rhno2, rchno3, routsec, routpri, conc_cf, koh, croutpri, somcsec,       &
-                  &  ar, rno2nox, ecvl, namseccor, buildingEffect, error)
+                  &  ar, rno2nox, ecvl, nam_subsec, buildingEffect, error)
                   
 USE m_commonconst
 USE m_error
@@ -60,7 +63,8 @@ REAL*4,    INTENT(IN)                            :: ddeppar
 REAL*4,    INTENT(IN)                            :: wdeppar                     
 INTEGER*4, INTENT(IN)                            :: ideh                        
 INTEGER*4, INTENT(IN)                            :: icm                         
-LOGICAL,   INTENT(IN)                            :: isec                        
+LOGICAL,   INTENT(IN)                            :: isec 
+INTEGER*4, INTENT(IN)                            :: nsubsec                      ! number of sub-secondary species                       
 INTEGER*4, INTENT(IN)                            :: iseiz                       
 INTEGER*4, INTENT(IN)                            :: mb                          
 REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) 
@@ -103,7 +107,7 @@ REAL*4,    INTENT(OUT)                           :: somcsec
 REAL*4,    INTENT(OUT)                           :: ar                          
 REAL*4,    INTENT(OUT)                           :: rno2nox                     
 REAL*4,    INTENT(OUT)                           :: ecvl(NSTAB, NTRAJ, *)       
-CHARACTER*(*), INTENT(OUT)                       :: namseccor 
+CHARACTER*(*), INTENT(OUT)                       :: nam_subsec(nsubsec) 
 type(TbuildingEffect), INTENT(OUT)               :: buildingEffect             ! structure with building effect tables
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
                 
@@ -181,7 +185,7 @@ IF (gasv) THEN                                                              ! if
       ! routsec : in-cloud scavenging ratio for secondary component
       !           (rout << rain-out = in-cloud) [-])
       ! conc_cf : concentration correction factor for output.
-      ! Section 6.3 OPS report
+      ! Section 6.3 OPS report FS
  
       knatdeppar = 3
       scavcoef = 0
@@ -200,7 +204,7 @@ IF (gasv) THEN                                                              ! if
          routsec  = 1.4e7
 
          ! Set parameters specific for NOx 
-         ! rhno2  : ratio [HNO2]/[NOx] based on measurements Speuld, Slanina et al 1990, but they report 4% (p. 66 OPS report)
+         ! rhno2  : ratio [HNO2]/[NOx] based on measurements Speuld, Slanina et al 1990, but they report 4% (p. 66 OPS report) FS
          ! koh    : second order reaction rate constant of reaction NO2 + OH -> HNO3 [cm3/(molec s)] 
          !          Baulch et al 1982 (OPS report Table 6.2 FS): kOH = 1.035e-11 cm3/(molec s) = 1000.9 ppb-1 h-1, at T = 0 C
          !                                                                                     =  932.6 ppb-1 h-1, at T = 20 C
@@ -243,10 +247,10 @@ ENDIF
 ! Component names (see m_commonconst for definition of CNAME)
 !
 IF (isec) THEN
-  namco     = CNAME(icm,1)
-  namsec    = CNAME(icm,2)
-  namseccor = CNAME(icm,3)
-  namse3    = CNAME(icm,4)
+  namco      = CNAME(icm,1)
+  namsec     = CNAME(icm,2)
+  nam_subsec = CNAME_SUBSEC
+  namse3     = CNAME(icm,4)
 ELSE
   namsec = namco
   namse3 = namco

--- a/ops_logfile.f90
+++ b/ops_logfile.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! FILENAME           : %M%
 ! SCCS (SOURCE)      : %P%
@@ -23,7 +26,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Martien de Haan (ARIS)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-F77/90
 ! DESCRIPTION        : Handling of log file. The log file is only opened and closed if something is written to it.

--- a/ops_main.f90
+++ b/ops_main.f90
@@ -125,8 +125,8 @@ INTEGER*4                                        :: ircp
 INTEGER*4                                        :: mmm
 INTEGER*4                                        :: ndone
 INTEGER*4                                        :: lu_rcp_dom                 ! dominant landuse class at receptor point
-REAL*4                                           :: lu_tra_per(NLU)            ! percentages of landuse classes over trajectorie
-REAL*4                                           :: lu_rcp_per(NLU)            ! percentages of landuse classes at receptor points
+real                                             :: lu_tra_per(NLU)            ! percentages of landuse classes over trajectorie
+real                                             :: lu_rcp_per(NLU)            ! percentages of landuse classes at receptor points
 INTEGER*4                                        :: i1(NTRAJ-1)                ! 
 INTEGER*4                                        :: year                        
 INTEGER*4                                        :: memdone                     
@@ -137,124 +137,124 @@ INTEGER*4                                        :: todo
 INTEGER*4                                        :: ntodo
 INTEGER*4                                        :: bottom
 
-REAL*4                                           :: aind                       ! hourglass
-REAL*4                                           :: amol2                       
-REAL*4                                           :: amol21                      
-REAL*4                                           :: z0_metreg_user             ! roughness length of user specified meteo region [m]      
-REAL*4                                           :: z0_user                    ! roughness length specified by user [m]
-REAL*4                                           :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
-REAL*4                                           :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
-REAL*4                                           :: z0_src                     ! roughness length at source; from z0-map [m]
-REAL*4                                           :: z0_tra                     ! roughness length representative for trajectory [m]
-REAL*4                                           :: vchemc                      
+real                                             :: aind                       ! hourglass
+real                                             :: amol2
+real                                             :: amol21
+real                                             :: z0_metreg_user             ! roughness length of user specified meteo region [m]
+real                                             :: z0_user                    ! roughness length specified by user [m]
+real                                             :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
+real                                             :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
+real                                             :: z0_src                     ! roughness length at source; from z0-map [m]
+real                                             :: z0_tra                     ! roughness length representative for trajectory [m]
+real                                             :: vchemc
 INTEGER*4                                        :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)                                                                                                                                            
-REAL*4                                           :: vchemv                      
-REAL*4                                           :: xc                          
-REAL*4                                           :: yc                          
-REAL*4                                           :: rc                          
-REAL*4                                           :: ugmoldep                    
-REAL*4                                           :: gemre 
-REAL*4                                           :: somcsec                     
-REAL*4                                           :: gemcpri
-REAL*4                                           :: gemcsec                    
-REAL*4                                           :: totddep                    
-REAL*4                                           :: gemddep                    
-REAL*4                                           :: gemddpri                   
-REAL*4                                           :: gemddsec                   
-REAL*4                                           :: ddrpri                     
-REAL*4                                           :: ddrsec                     
-REAL*4                                           :: totwdep                    
-REAL*4                                           :: gemwdep                    
-REAL*4                                           :: gemwdpri                   
-REAL*4                                           :: gemwdsec                   
-REAL*4                                           :: wdrpri                     
-REAL*4                                           :: wdrsec                     
-REAL*4                                           :: tottdep                    
-REAL*4                                           :: gemtdep                    
-REAL*4                                           :: gemprec                    
-REAL*4                                           :: ccr                        
-REAL*4                                           :: xorg                       
-REAL*4                                           :: yorg                       
-REAL*4                                           :: bdiam(LSBUF)               
-REAL*4                                           :: bsterkte(LSBUF)            
-REAL*4                                           :: bwarmte(LSBUF)             
-REAL*4                                           :: bhoogte(LSBUF)             
-REAL*4                                           :: bsigmaz(LSBUF)    
-REAL*4                                           :: bD_stack(LSBUF)           ! diameter of the stack [m]
-REAL*4                                           :: bV_stack(LSBUF)           ! exit velocity of plume at stack tip [m/s]
-REAL*4                                           :: bTs_stack(LSBUF)          ! temperature of effluent from stack [K]            
+real                                             :: vchemv
+real                                             :: xc
+real                                             :: yc
+real                                             :: rc
+real                                             :: ugmoldep
+real                                             :: gemre
+real                                             :: somcsec
+real                                             :: gemcpri
+real                                             :: gemcsec
+real                                             :: totddep
+real                                             :: gemddep
+real                                             :: gemddpri
+real                                             :: gemddsec
+real                                             :: ddrpri
+real                                             :: ddrsec
+real                                             :: totwdep
+real                                             :: gemwdep
+real                                             :: gemwdpri
+real                                             :: gemwdsec
+real                                             :: wdrpri
+real                                             :: wdrsec
+real                                             :: tottdep
+real                                             :: gemtdep
+real                                             :: gemprec
+real                                             :: ccr
+real                                             :: xorg
+real                                             :: yorg
+real                                             :: bdiam(LSBUF)
+real                                             :: bsterkte(LSBUF)
+real                                             :: bwarmte(LSBUF)
+real                                             :: bhoogte(LSBUF)
+real                                             :: bsigmaz(LSBUF)
+real                                             :: bD_stack(LSBUF)           ! diameter of the stack [m]
+real                                             :: bV_stack(LSBUF)           ! exit velocity of plume at stack tip [m/s]
+real                                             :: bTs_stack(LSBUF)          ! temperature of effluent from stack [K]
 LOGICAL                                          :: bemis_horizontal(LSBUF)   ! horizontal outflow of emission
 type(Tbuilding)                                  :: bbuilding(LSBUF)          ! array with structures with building parameters
 LOGICAL                                          :: building_present1         ! at least one building is present in the source file   
-REAL*4                                           :: emis(6,NLANDMAX) 
-REAL*4                                           :: conc_cf
-REAL*4                                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)  
-REAL*4                                           :: ar                          
-REAL*4                                           :: rno2nox                     
-REAL*4                                           :: uurtot                      
-REAL*4                                           :: zf                          
-REAL*4                                           :: trafst(NTRAJ)               
-REAL*4                                           :: bqrv(LSBUF)                 
-REAL*4                                           :: bqtr(LSBUF)                 
-REAL*4                                           :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)  
-REAL*4                                           :: rainreg(NMETREG)            
-REAL*4                                           :: z0_metreg(NMETREG)    ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]           
-REAL*4                                           :: xreg(NMETREG)               
-REAL*4                                           :: yreg(NMETREG)               
-REAL*4                                           :: hourreg(NMETREG)            
-REAL*4                                           :: ecvl(NSTAB, NTRAJ,2*MAXDISTR) 
-REAL*4                                           :: dverl(NHRBLOCKS,MAXDISTR)   
-REAL*4                                           :: usdverl(NHRBLOCKS,MAXDISTR) 
-REAL*4                                           :: pmd(NPARTCLASS,MAXDISTR)    
-REAL*4                                           :: uspmd(NPARTCLASS,MAXDISTR)  
-REAL*4                                           :: amol1                      
-REAL*4                                           :: emtrend                    
-REAL*4                                           :: grid                       
-REAL*4                                           :: wdeppar                    
-REAL*4                                           :: scavcoef                   
-REAL*4                                           :: routsec                    ! in-cloud scavenging ratio for secondary component
+real                                             :: emis(6,NLANDMAX)
+real                                             :: conc_cf
+real                                             :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real                                             :: ar
+real                                             :: rno2nox
+real                                             :: uurtot
+real                                             :: zf
+real                                             :: trafst(NTRAJ)
+real                                             :: bqrv(LSBUF)
+real                                             :: bqtr(LSBUF)
+real                                             :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)
+real                                             :: rainreg(NMETREG)
+real                                             :: z0_metreg(NMETREG)    ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
+real                                             :: xreg(NMETREG)
+real                                             :: yreg(NMETREG)
+real                                             :: hourreg(NMETREG)
+real                                             :: ecvl(NSTAB, NTRAJ,2*MAXDISTR)
+real                                             :: dverl(NHRBLOCKS,MAXDISTR)
+real                                             :: usdverl(NHRBLOCKS,MAXDISTR)
+real                                             :: pmd(NPARTCLASS,MAXDISTR)
+real                                             :: uspmd(NPARTCLASS,MAXDISTR)
+real                                             :: amol1
+real                                             :: emtrend
+real                                             :: grid
+real                                             :: wdeppar
+real                                             :: scavcoef
+real                                             :: routsec                    ! in-cloud scavenging ratio for secondary component
                                                                                ! (rout << rain-out = in-cloud) [-]
-REAL*4                                           :: routpri                    ! in-cloud scavenging ratio for primary component
+real                                             :: routpri                    ! in-cloud scavenging ratio for primary component
                                                                                ! (rout << rain-out = in-cloud) [-]
-REAL*4                                           :: croutpri                   ! constant (initial) in-cloud scavenging ratio [-] for primary component                                   
-REAL*4                                           :: rcno                       
-REAL*4                                           :: rhno2                      
-REAL*4                                           :: rchno3                     
-REAL*4                                           :: dg                         
-REAL*4                                           :: dispg(NSTAB)               
-REAL*4                                           :: ddeppar                    
-REAL*4                                           :: koh                        
-REAL*4                                           :: so2sek(NSEK)               
-REAL*4                                           :: no2sek(NSEK)               
-REAL*4, DIMENSION(:), POINTER                    :: gem_subsec                 ! grid mean for concentration of sub-secondary species [ug/m3]     
-REAL*4                                           :: scale_con                  
-REAL*4                                           :: scale_sec                  
-REAL*4, DIMENSION(:), POINTER                    :: scale_subsec              
-REAL*4                                           :: scale_dep                  
-REAL*4                                           :: so2bgtra                   ! 
-REAL*4                                           :: no2bgtra                   ! 
-REAL*4                                           :: nh3bgtra                   ! 
+real                                             :: croutpri                   ! constant (initial) in-cloud scavenging ratio [-] for primary component
+real                                             :: rcno
+real                                             :: rhno2
+real                                             :: rchno3
+real                                             :: dg
+real                                             :: dispg(NSTAB)
+real                                             :: ddeppar
+real                                             :: koh
+real                                             :: so2sek(NSEK)
+real                                             :: no2sek(NSEK)
+real,   DIMENSION(:), POINTER                    :: gem_subsec                 ! grid mean for concentration of sub-secondary species [ug/m3]
+real                                             :: scale_con
+real                                             :: scale_sec
+real,   DIMENSION(:), POINTER                    :: scale_subsec
+real                                             :: scale_dep
+real                                             :: so2bgtra
+real                                             :: no2bgtra
+real                                             :: nh3bgtra
 type(Tvchem)                                     :: vchem2                     
-REAL*8, DIMENSION(:), POINTER                    :: sdrypri_arr                 
-REAL*8                                           :: sdrypri                     
-REAL*8, DIMENSION(:), POINTER                    :: snatpri_arr                 
-REAL*8                                           :: snatpri                     
-REAL*8, DIMENSION(:), POINTER                    :: somvnpri_arr                
-REAL*8                                           :: somvnpri                    
-REAL*8, DIMENSION(:), POINTER                    :: telvnpri_arr                
-REAL*8                                           :: telvnpri                    
-REAL*8, DIMENSION(:), POINTER                    :: sdrysec_arr                 
-REAL*8                                           :: sdrysec                     
-REAL*8, DIMENSION(:), POINTER                    :: snatsec_arr                 
-REAL*8                                           :: snatsec                     
-REAL*8, DIMENSION(:), POINTER                    :: somvnsec_arr                
-REAL*8                                           :: somvnsec                    
-REAL*8, DIMENSION(:), POINTER                    :: telvnsec_arr                
-REAL*8                                           :: telvnsec                    
-REAL*8, DIMENSION(:), POINTER                    :: vvchem_arr                  
-REAL*8                                           :: vvchem                      
-REAL*8, DIMENSION(:), POINTER                    :: vtel_arr                    
-REAL*8                                           :: vtel                        
+double precision, DIMENSION(:), POINTER          :: sdrypri_arr
+double precision                                 :: sdrypri
+double precision, DIMENSION(:), POINTER          :: snatpri_arr
+double precision                                 :: snatpri
+double precision, DIMENSION(:), POINTER          :: somvnpri_arr
+double precision                                 :: somvnpri
+double precision, DIMENSION(:), POINTER          :: telvnpri_arr
+double precision                                 :: telvnpri
+double precision, DIMENSION(:), POINTER          :: sdrysec_arr
+double precision                                 :: sdrysec
+double precision, DIMENSION(:), POINTER          :: snatsec_arr
+double precision                                 :: snatsec
+double precision, DIMENSION(:), POINTER          :: somvnsec_arr
+double precision                                 :: somvnsec
+double precision, DIMENSION(:), POINTER          :: telvnsec_arr
+double precision                                 :: telvnsec
+double precision, DIMENSION(:), POINTER          :: vvchem_arr
+double precision                                 :: vvchem
+double precision, DIMENSION(:), POINTER          :: vtel_arr
+double precision                                 :: vtel
 
 CHARACTER*512                                    :: namco                      
 CHARACTER*80                                     :: project                    
@@ -290,32 +290,33 @@ INTEGER*4, DIMENSION(:), POINTER                 :: landsel                    !
 INTEGER*4, DIMENSION(:), POINTER                 :: lu_rcp_dom_all             ! land use at receptor points
 INTEGER*4, DIMENSION(:), POINTER                 :: jump                       ! indices skipped because grid cell is outside NL
 
-REAL*4,    DIMENSION(:), POINTER                 :: xm                         
-REAL*4,    DIMENSION(:), POINTER                 :: ym                         
-REAL*4,    DIMENSION(:), POINTER                 :: zm                         
-REAL*4,    DIMENSION(:), POINTER                 :: frac                       ! fraction of output cell on land surface
+real,      DIMENSION(:), POINTER                 :: xm
+real,      DIMENSION(:), POINTER                 :: ym
+real,      DIMENSION(:), POINTER                 :: zm
+real,      DIMENSION(:), POINTER                 :: frac                       ! fraction of output cell on land surface
 INTEGER,   DIMENSION(:,:), POINTER               :: lu_rcp_per_user_all        ! percentage of landuse for all receptors, used defined in receptor file
-REAL*4,    DIMENSION(:), POINTER                 :: gxm                        
-REAL*4,    DIMENSION(:), POINTER                 :: gym                        
-REAL*4,    DIMENSION(:), POINTER                 :: z0_rcp_all                 ! roughness lengths for all receptors; from z0-map or receptor file [m]
-REAL*4,    DIMENSION(:), POINTER                 :: rhno3_rcp                 
-REAL*4,    DIMENSION(:,:), ALLOCATABLE           :: f_subsec_rcp               ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]                                                                                                                                                                          
-REAL*4,    DIMENSION(:), POINTER                 :: precip                     
+real,      DIMENSION(:), POINTER                 :: gxm
+real,      DIMENSION(:), POINTER                 :: gym
+real,      DIMENSION(:), POINTER                 :: z0_rcp_all                 ! roughness lengths for all receptors; from z0-map or receptor file [m]
+real,      DIMENSION(:), POINTER                 :: rhno3_rcp
+real,      DIMENSION(:,:), ALLOCATABLE           :: f_subsec_rcp               ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
+real,      DIMENSION(:), POINTER                 :: precip
 DOUBLE PRECISION,    DIMENSION(:,:), POINTER     :: cpri_d                     ! concentration of primary component, double precision [ug/m3]
-REAL*4,    DIMENSION(:), POINTER                 :: cpri                       ! concentration of primary component [ug/m3]
+real,      DIMENSION(:), POINTER                 :: cpri                       ! concentration of primary component [ug/m3]
 DOUBLE PRECISION,    DIMENSION(:,:), POINTER     :: csec_d                     ! concentration of secondary component, double precision [ug/m3]
-REAL*4,    DIMENSION(:), POINTER                 :: csec                       ! concentration of secondary component [ug/m3]
+real,      DIMENSION(:), POINTER                 :: csec                       ! concentration of secondary component [ug/m3]
 DOUBLE PRECISION,    DIMENSION(:,:), POINTER     :: drydep_d                    
-REAL*4,    DIMENSION(:), POINTER                 :: drydep                      
+real,      DIMENSION(:), POINTER                 :: drydep
 DOUBLE PRECISION,    DIMENSION(:,:), POINTER     :: wetdep_d                    
-REAL*4,    DIMENSION(:), POINTER                 :: wetdep                      
+real,      DIMENSION(:), POINTER                 :: wetdep
 DOUBLE PRECISION,    DIMENSION(:,:), POINTER     :: ddepri_d                   
-REAL*4,    DIMENSION(:), POINTER                 :: ddepri                      
-REAL*4,    DIMENSION(:), POINTER                 :: totdep                      
-REAL*4,    DIMENSION(:,:), POINTER               :: csubsec                    ! concentration of sub-secondary species [ug/m3]                
-REAL*4,    DIMENSION(:), POINTER                 :: nh3bg_rcp                  
-REAL*4,    DIMENSION(:), POINTER                 :: so2bg_rcp                  
-REAL*4,    DIMENSION(:), POINTER                 :: rno2_nox_sum               ! NO2/NOx ratio, weighed sum over classes
+real,      DIMENSION(:), POINTER                 :: ddepri
+real,      DIMENSION(:), POINTER                 :: totdep
+real,      DIMENSION(:,:), POINTER               :: csubsec                    ! concentration of sub-secondary species [ug/m3]
+real,      DIMENSION(:), POINTER                 :: nh3bg_rcp
+real,      DIMENSION(:), POINTER                 :: so2bg_rcp
+real,      DIMENSION(:), POINTER                 :: rno2_nox_sum               ! NO2/NOx ratio, weighed sum over classes
+real:: r1mach
 
 CHARACTER*12, DIMENSION(:), POINTER              :: namrcp                     ! receptor names
 

--- a/ops_neutral.f90
+++ b/ops_neutral.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ / Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : This routine calculates sigmaz for near neutral cases according to Gryning et al. (1987).

--- a/ops_neutral.f90
+++ b/ops_neutral.f90
@@ -50,31 +50,31 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_neutral')
 
 ! CONSTANTS
-REAL*4                                           :: A                          ! correctiefactor to obtain equal limit values |L| > $ 
-REAL*4                                           :: K                          ! von Karmanconstante
+real                                             :: A                          ! correctiefactor to obtain equal limit values |L| > $
+real                                             :: K                          ! von Karmanconstante
 PARAMETER   (A = 1. )
 PARAMETER   (K = 0.4)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z0                         ! roughness length (m)
-REAL*4,    INTENT(IN)                            :: zi                         ! mixing height (m)
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity (m)
-REAL*4,    INTENT(IN)                            :: h                          ! source heigth (including plume rise) (m)
-REAL*4,    INTENT(IN)                            :: x                          ! downwind distance  (m)
+real,      INTENT(IN)                            :: z0                         ! roughness length (m)
+real,      INTENT(IN)                            :: zi                         ! mixing height (m)
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
+real,      INTENT(IN)                            :: uster                      ! friction velocity (m)
+real,      INTENT(IN)                            :: h                          ! source heigth (including plume rise) (m)
+real,      INTENT(IN)                            :: x                          ! downwind distance  (m)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uh                         ! windspeed at downwind distance x and height zu (m/s)
-REAL*4,    INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection 
+real,      INTENT(OUT)                           :: uh                         ! windspeed at downwind distance x and height zu (m/s)
+real,      INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection
                                                                                ! at the top of the mixing layer and at the ground surface
-REAL*4,    INTENT(OUT)                           :: szn                        ! vertical dispersion coefficient for near neutral upper layer (m)
+real,      INTENT(OUT)                           :: szn                        ! vertical dispersion coefficient for near neutral upper layer (m)
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: last                       ! 
-REAL*4                                           :: fz                         ! 
-REAL*4                                           :: s                          ! 
-REAL*4                                           :: sw                         ! 
-REAL*4                                           :: tl                         ! 
+real                                             :: fz
+real                                             :: s
+real                                             :: sw
+real                                             :: tl
 LOGICAL                                          :: finished                   ! 
 
 ! SCCS-ID VARIABLES

--- a/ops_outp_prep.f90
+++ b/ops_outp_prep.f90
@@ -48,23 +48,23 @@ IMPLICIT NONE
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! 
 INTEGER*4, INTENT(IN)                            :: icm                        ! 
 INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species                       
-REAL*4,    INTENT(IN)                            :: conc_cf                    ! 
-REAL*4,    INTENT(IN)                            :: rhno3_rcp(nrrcp)           ! 
-REAL*4,    INTENT(OUT)                           :: f_subsec_rcp(nrrcp,nsubsec)   ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
-REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! 
-REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! 
-REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! 
+real,      INTENT(IN)                            :: conc_cf
+real,      INTENT(IN)                            :: rhno3_rcp(nrrcp)
+real,      INTENT(OUT)                           :: f_subsec_rcp(nrrcp,nsubsec)   ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
+real,      INTENT(IN)                            :: csec(nrrcp)
+real,      INTENT(IN)                            :: drydep(nrrcp)
+real,      INTENT(IN)                            :: wetdep(nrrcp)
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: cpri(nrrcp)                ! 
+real,      INTENT(INOUT)                         :: cpri(nrrcp)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: totdep(nrrcp)              ! 
-REAL*4,    INTENT(OUT)                           :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
-REAL*4,    INTENT(OUT)                           :: scale_con                  ! 
-REAL*4,    INTENT(OUT)                           :: scale_sec                  ! 
-REAL*4,    INTENT(OUT)                           :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
-REAL*4,    INTENT(OUT)                           :: scale_dep                  ! 
+real,      INTENT(OUT)                           :: totdep(nrrcp)
+real,      INTENT(OUT)                           :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
+real,      INTENT(OUT)                           :: scale_con
+real,      INTENT(OUT)                           :: scale_sec
+real,      INTENT(OUT)                           :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
+real,      INTENT(OUT)                           :: scale_dep
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species

--- a/ops_outp_prep.f90
+++ b/ops_outp_prep.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Wilco de Vries
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Prepare output process (print/plot)
@@ -36,16 +39,18 @@
 ! CALLED FUNCTIONS   :
 ! UPDATE HISTORY :
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_outp_prep(nrrcp, icm, conc_cf, rhno3_rcp, csec, drydep, wetdep, cpri, totdep, cseccor, scale_con, scale_sec,     &
-                      &  scale_sec_cor, scale_dep)
+SUBROUTINE ops_outp_prep(nrrcp, icm, nsubsec, conc_cf, rhno3_rcp, f_subsec_rcp, csec, drydep, wetdep, cpri, totdep, csubsec, scale_con, scale_sec,     &
+                      &  scale_subsec, scale_dep)
 
 IMPLICIT NONE
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! 
 INTEGER*4, INTENT(IN)                            :: icm                        ! 
+INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species                       
 REAL*4,    INTENT(IN)                            :: conc_cf                    ! 
 REAL*4,    INTENT(IN)                            :: rhno3_rcp(nrrcp)           ! 
+REAL*4,    INTENT(OUT)                           :: f_subsec_rcp(nrrcp,nsubsec)   ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
 REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! 
 REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! 
 REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! 
@@ -55,14 +60,14 @@ REAL*4,    INTENT(INOUT)                         :: cpri(nrrcp)                !
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 REAL*4,    INTENT(OUT)                           :: totdep(nrrcp)              ! 
-REAL*4,    INTENT(OUT)                           :: cseccor(nrrcp)             ! 
+REAL*4,    INTENT(OUT)                           :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
 REAL*4,    INTENT(OUT)                           :: scale_con                  ! 
 REAL*4,    INTENT(OUT)                           :: scale_sec                  ! 
-REAL*4,    INTENT(OUT)                           :: scale_sec_cor              ! 
+REAL*4,    INTENT(OUT)                           :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
 REAL*4,    INTENT(OUT)                           :: scale_dep                  ! 
 
 ! LOCAL VARIABLES
-INTEGER*4                                        :: j                          ! 
+INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -73,28 +78,20 @@ CHARACTER*81                                     :: sccsida                    !
 sccsida = '%W%:%E%'//char(0)
 !-------------------------------------------------------------------------------------------------------------------------------
 !
-! Calculate 
-! 1. totdep = total deposition = dry deposition + wet deposition
-! 2. corrected NOx concentration (to account for HNO2 and PAN contributions to NO2)
-! 3. concentration of second secondary substance; 
-!
-! rhno3 = ratio [HNO3]/[NO3]_total (NO3_total = HNO3+NO3_aerosol)
-!
-!                                            [HNO3]            [NO3_aerosol]
-! cseccor = csec (1 - rhno3) = csec (1 - ------------ ) = csec ------------- = [NO3_aerosol]
-!                                         [NO3]_total           [NO3]_total
-!
-DO j = 1, nrrcp
-  totdep(j) = drydep(j) + wetdep(j)
-  IF (icm == 2) THEN
-    cpri(j)    = cpri(j) * conc_cf 
-    cseccor(j) = csec(j) - csec(j) * rhno3_rcp(j) 
-  ENDIF
-ENDDO
+! 1. Calculate totdep = total deposition = dry deposition + wet deposition
+! 2. Correct cpri = NOx concentration (to account for HNO2 and PAN contributions to NO2)
+! 3. Calculate concentration of sub-secondary species 
+totdep = drydep + wetdep
+IF (icm == 2) THEN
+   cpri = cpri * conc_cf 
+   do isubsec = 1,nsubsec
+      csubsec(:,isubsec) = f_subsec_rcp(:,isubsec)*csec
+   enddo
+ENDIF
 !
 ! Scaling factors for concentration and deposition fields
 !
-CALL ops_scalefac(nrrcp, cpri, csec, drydep, wetdep, scale_con, scale_sec, scale_dep, cseccor, scale_sec_cor)
+CALL ops_scalefac(nrrcp, nsubsec, cpri, csec, drydep, wetdep, scale_con, scale_sec, scale_dep, csubsec, scale_subsec)
 
 RETURN
 

--- a/ops_par_chem.f90
+++ b/ops_par_chem.f90
@@ -55,35 +55,35 @@ PARAMETER    (ROUTINENAAM = 'ops_par_chem')
 INTEGER*4, INTENT(IN)                            :: icm  
 INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)                      
 INTEGER*4, INTENT(IN)                            :: isek                        
-REAL*4,    INTENT(IN)                            :: so2sek(NSEK)               
-REAL*4,    INTENT(IN)                            :: no2sek(NSEK)               
-REAL*4,    INTENT(IN)                            :: so2bgtra                    
-REAL*4,    INTENT(IN)                            :: no2bgtra                    
-REAL*4,    INTENT(IN)                            :: nh3bgtra                    
+real,      INTENT(IN)                            :: so2sek(NSEK)
+real,      INTENT(IN)                            :: no2sek(NSEK)
+real,      INTENT(IN)                            :: so2bgtra
+real,      INTENT(IN)                            :: no2bgtra
+real,      INTENT(IN)                            :: nh3bgtra
 type(Tvchem),    INTENT(INOUT)                   :: vchem2
-REAL*4,    INTENT(IN)                            :: disx                       
-REAL*4,    INTENT(IN)                            :: diameter              
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: diameter
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: vchemnh3
-REAL*4,    INTENT(OUT)                           :: rhno3                       
-REAL*4,    INTENT(OUT)                           :: rrno2nox                   
-REAL*4,    INTENT(OUT)                           :: rations                    
+real,      INTENT(OUT)                           :: vchemnh3
+real,      INTENT(OUT)                           :: rhno3
+real,      INTENT(OUT)                           :: rrno2nox
+real,      INTENT(OUT)                           :: rations
 
 ! LOCAL VARIABLES
-REAL*4                                           :: C1                         ! 
-REAL*4                                           :: C2                         ! 
-REAL*4                                           :: ch                         ! 
-REAL*4                                           :: cr                         ! 
-REAL*4                                           :: wdc_so2                    ! 
-REAL*4                                           :: wdc_no2                    ! 
-REAL*4                                           :: so2bgtra_corr              ! 
-REAL*4                                           :: no2bgtra_corr              ! 
-REAL*4                                           :: nh3bgtra_corr              ! 
-REAL*4                                           :: nox_threshold              ! threshold value for NOx in log-function in NOx -> NO2 conversion
-REAL*4                                           :: no2_threshold              ! threshold value for NO2 in exp-function in NO2 -> NOx conversion
-REAL*4                                           :: alpha                      ! slope of linear function NOx -> NO2 conversion
-REAL*4                                           :: noxbgtra_corr              ! conversion of no2bgtra_corr to NOx
+real                                             :: C1
+real                                             :: C2
+real                                             :: ch
+real                                             :: cr
+real                                             :: wdc_so2
+real                                             :: wdc_no2
+real                                             :: so2bgtra_corr
+real                                             :: no2bgtra_corr
+real                                             :: nh3bgtra_corr
+real                                             :: nox_threshold              ! threshold value for NOx in log-function in NOx -> NO2 conversion
+real                                             :: no2_threshold              ! threshold value for NO2 in exp-function in NO2 -> NOx conversion
+real                                             :: alpha                      ! slope of linear function NOx -> NO2 conversion
+real                                             :: noxbgtra_corr              ! conversion of no2bgtra_corr to NOx
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_plot_uitv.f90
+++ b/ops_plot_uitv.f90
@@ -56,25 +56,25 @@ CHARACTER*(*), INTENT(IN)                        :: coneh                      !
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! 
 INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species
 INTEGER*4, INTENT(IN)                            :: jump(nrrcp+1)              ! distance between receptor points in grid units
-REAL*4,    INTENT(IN)                            :: xorg                       ! 
-REAL*4,    INTENT(IN)                            :: yorg                       ! 
+real,      INTENT(IN)                            :: xorg
+real,      INTENT(IN)                            :: yorg
 INTEGER*4, INTENT(IN)                            :: nrcol                      ! number of columns in grid
 INTEGER*4, INTENT(IN)                            :: nrrow                      ! number of row in grid
-REAL*4,    INTENT(IN)                            :: grid                       ! 
+real,      INTENT(IN)                            :: grid
 LOGICAL,   INTENT(IN)                            :: idep                       ! 
 CHARACTER*(*), INTENT(IN)                        :: namco                      ! 
 CHARACTER*(*), INTENT(IN)                        :: namse3                     ! 
 CHARACTER*(*), INTENT(IN)                        :: namsec                     ! 
 CHARACTER*(*), INTENT(IN)                        :: depeh                      ! 
 CHARACTER*(*), INTENT(IN)                        :: namrcp(nrrcp)              ! 
-REAL*4,    INTENT(IN)                            :: xm(nrrcp)                  ! 
-REAL*4,    INTENT(IN)                            :: ym(nrrcp)                  ! 
-REAL*4,    INTENT(IN)                            :: cpri(nrrcp)                ! 
-REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! 
-REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! 
-REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! 
+real,      INTENT(IN)                            :: xm(nrrcp)
+real,      INTENT(IN)                            :: ym(nrrcp)
+real,      INTENT(IN)                            :: cpri(nrrcp)
+real,      INTENT(IN)                            :: csec(nrrcp)
+real,      INTENT(IN)                            :: drydep(nrrcp)
+real,      INTENT(IN)                            :: wetdep(nrrcp)
 INTEGER*4, INTENT(IN)                            :: icm                        ! 
-REAL*4,    INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
+real,      INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
 CHARACTER*(*), INTENT(IN)                        :: nam_subsec(nsubsec)        ! names of sub-secondary species
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
@@ -84,9 +84,9 @@ TYPE (TError), INTENT(OUT)                       :: error                      !
 INTEGER*4                                        :: ierr                       ! 
 INTEGER*4                                        :: ls                         ! lengte textstring namse3
 INTEGER*4                                        :: j                          ! 
-REAL*4                                           :: xlb                        ! 
-REAL*4                                           :: ylb                        ! 
-REAL*4                                           :: totdep(nrrcp)              ! 
+real                                             :: xlb
+real                                             :: ylb
+real                                             :: totdep(nrrcp)
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
 
 ! CONSTANTS
@@ -263,8 +263,8 @@ CHARACTER*(*), INTENT(IN)                        :: descco                     !
 CHARACTER*(*), INTENT(IN)                        :: compname                   ! name of component
 CHARACTER*(*), INTENT(IN)                        :: compunit                   ! component unit
 REAL,      INTENT(IN)                            :: grid                       ! grid size in km
-REAL*4,    INTENT(IN)                            :: xlb                        ! aps-formatted x-origin (?)
-REAL*4,    INTENT(IN)                            :: ylb                        ! aps-formatted y-origin (?)
+real,      INTENT(IN)                            :: xlb                        ! aps-formatted x-origin (?)
+real,      INTENT(IN)                            :: ylb                        ! aps-formatted y-origin (?)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 TYPE (TError), INTENT(OUT)                       :: error                      ! Error handling record
@@ -274,7 +274,7 @@ INTEGER                                          :: j                          !
 INTEGER                                          :: m                          ! do loop counter
 INTEGER                                          :: ierr                       ! error number
 INTEGER                                          :: pointto                    ! current receptor point index on line
-REAL*4                                           :: line(nrcol)                ! value from each row
+real                                             :: line(nrcol)                ! value from each row
 CHARACTER*80                                     :: formatstring               ! format string in writing
 CHARACTER*10                                     :: OPSVERSIE                  ! format string in writing
 ! ---

--- a/ops_plrise71.f90
+++ b/ops_plrise71.f90
@@ -56,26 +56,26 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_plrise71')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z0                         ! 
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhovlengte
-REAL*4,    INTENT(IN)                            :: uster                      ! frictiesnelheid
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: qw                         ! warmte inhoud van het rookgas (MW)
-REAL*4,    INTENT(IN)                            :: xloc                       ! 
+real,      INTENT(IN)                            :: z0
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhovlengte
+real,      INTENT(IN)                            :: uster                      ! frictiesnelheid
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: qw                         ! warmte inhoud van het rookgas (MW)
+real,      INTENT(IN)                            :: xloc
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: htt                        ! 
-REAL*4,    INTENT(OUT)                           :: onder                      ! 
+real,      INTENT(OUT)                           :: htt
+real,      INTENT(OUT)                           :: onder
 
 ! LOCAL VARIABLES
-REAL*4                                           :: delh                       ! 
-REAL*4                                           :: f                          ! 
-REAL*4                                           :: us                        ! wind speed at effective plume height
+real                                             :: delh
+real                                             :: f
+real                                             :: us                        ! wind speed at effective plume height
                                                                                ! representative for the whole plume rise length
-REAL*4                                           :: dtdz                       ! 
-REAL*4                                           :: hs                          ! 
-REAL*4                                           :: s                          ! 
+real                                             :: dtdz
+real                                             :: hs
+real                                             :: s
 
 ! Iteration variables
 ! iteration converges if |delh - delh_prev| < epsa + epsr*delh

--- a/ops_plrise71.f90
+++ b/ops_plrise71.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,14 +27,14 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ 940217 /Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Deze routine berekent de pluimhoogte.
 !    This routine includes plume rise formulations given by Briggs(1969) and Briggs(1971)
 !    This method is equal to the method used in the (old) Dutch National Model (TNO, 1976).
 !    The formulas used in 'STACKS' are the same, except for convective cases (Erbrink, 1995)
-!                                                HvJ 960121
+!                                                  960121
 !    Extra iteration, because wind speed depends on plume height and vice versa
 !
 ! EXIT CODES         :

--- a/ops_print_grid.f90
+++ b/ops_print_grid.f90
@@ -68,48 +68,48 @@ CHARACTER*(*), INTENT(IN)                        :: namco                      !
 CHARACTER*(*), INTENT(IN)                        :: namse3                     ! 
 CHARACTER*(*), INTENT(IN)                        :: coneh                      ! concentration unit
 CHARACTER*(*), INTENT(IN)                        :: depeh                      ! deposition unit
-REAL*4,    INTENT(IN)                            :: conc_cf                    ! concentration correction factor
-REAL*4,    INTENT(IN)                            :: amol21                     ! 
-REAL*4,    INTENT(IN)                            :: ugmoldep                   ! 
+real,      INTENT(IN)                            :: conc_cf                    ! concentration correction factor
+real,      INTENT(IN)                            :: amol21
+real,      INTENT(IN)                            :: ugmoldep
 INTEGER*4, INTENT(IN)                            :: nrcol                      ! number of grid cells in X-dir
 INTEGER*4, INTENT(IN)                            :: nrrow                      ! number of grid cells in Y-dir
-REAL*4,    INTENT(IN)                            :: grid                       ! grid cell dimension
-REAL*4,    INTENT(IN)                            :: xorg                       ! X-coor of grid origin
-REAL*4,    INTENT(IN)                            :: yorg                       ! Y-coor of grid origin
-REAL*4,    INTENT(IN)                            :: precip(nrrcp)              ! calculated precipitation
-REAL*4,    INTENT(IN)                            :: cpri(nrrcp)                ! primary concentration
-REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! secondary concentration
-REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! dry deposition
-REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! wet deposition
-REAL*4,    INTENT(IN)                            :: ddepri(nrrcp)              ! dry depo of primary comp.
+real,      INTENT(IN)                            :: grid                       ! grid cell dimension
+real,      INTENT(IN)                            :: xorg                       ! X-coor of grid origin
+real,      INTENT(IN)                            :: yorg                       ! Y-coor of grid origin
+real,      INTENT(IN)                            :: precip(nrrcp)              ! calculated precipitation
+real,      INTENT(IN)                            :: cpri(nrrcp)                ! primary concentration
+real,      INTENT(IN)                            :: csec(nrrcp)                ! secondary concentration
+real,      INTENT(IN)                            :: drydep(nrrcp)              ! dry deposition
+real,      INTENT(IN)                            :: wetdep(nrrcp)              ! wet deposition
+real,      INTENT(IN)                            :: ddepri(nrrcp)              ! dry depo of primary comp.
 INTEGER*4, INTENT(IN)                            :: lu_rcp_dom_all(nrrcp)      ! land use 
-REAL*4,    INTENT(IN)                            :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
-REAL*4,    INTENT(IN)                            :: gemcpri                    ! grid mean for prim. concentration
-REAL*4,    INTENT(IN)                            :: gemcsec                    ! grid mean for sec. concentration
-REAL*4,    INTENT(IN)                            :: ccr                        ! eff. chemical conversion rate
-REAL*4,    INTENT(IN)                            :: gemddep                    ! grid mean for dry deposition
-REAL*4,    INTENT(IN)                            :: gemddpri                   ! grid mean for dry deposition (pri)
-REAL*4,    INTENT(IN)                            :: gemddsec                   ! grid mean for dry deposition (sec)
-REAL*4,    INTENT(IN)                            :: totddep                    ! grid total dry deposition (g/s)
-REAL*4,    INTENT(IN)                            :: ddrpri                     ! eff. dry deposition rate (prim)
-REAL*4,    INTENT(IN)                            :: ddrsec                     ! eff. dry deposition rate (sec)
-REAL*4,    INTENT(IN)                            :: gemwdep                    ! grid mean for wet deposition (tot)
-REAL*4,    INTENT(IN)                            :: gemwdpri                   ! grid mean for wet deposition (pri)
-REAL*4,    INTENT(IN)                            :: gemwdsec                   ! grid mean for wet deposition (sec)
-REAL*4,    INTENT(IN)                            :: totwdep                    ! grid total wet deposition (g/s)
-REAL*4,    INTENT(IN)                            :: wdrpri                     ! effective wet deposition rate (primary component) [%/h]
-REAL*4,    INTENT(IN)                            :: wdrsec                     ! effective wet deposition rate (secondary component) [%/h]
-REAL*4,    INTENT(IN)                            :: gemprec                    ! grid mean annual precpitation from meteo
-REAL*4,    INTENT(IN)                            :: gemtdep                    ! grid mean for total deposition
-REAL*4,    INTENT(IN)                            :: tottdep                    ! grid total total deposition
-REAL*4,    INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary substance [ug/m3]
-REAL*4,    INTENT(IN)                            :: gem_subsec(nsubsec)        ! grid mean for concentration of sub-secondary species [ug/m3]
+real,      INTENT(IN)                            :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
+real,      INTENT(IN)                            :: gemcpri                    ! grid mean for prim. concentration
+real,      INTENT(IN)                            :: gemcsec                    ! grid mean for sec. concentration
+real,      INTENT(IN)                            :: ccr                        ! eff. chemical conversion rate
+real,      INTENT(IN)                            :: gemddep                    ! grid mean for dry deposition
+real,      INTENT(IN)                            :: gemddpri                   ! grid mean for dry deposition (pri)
+real,      INTENT(IN)                            :: gemddsec                   ! grid mean for dry deposition (sec)
+real,      INTENT(IN)                            :: totddep                    ! grid total dry deposition (g/s)
+real,      INTENT(IN)                            :: ddrpri                     ! eff. dry deposition rate (prim)
+real,      INTENT(IN)                            :: ddrsec                     ! eff. dry deposition rate (sec)
+real,      INTENT(IN)                            :: gemwdep                    ! grid mean for wet deposition (tot)
+real,      INTENT(IN)                            :: gemwdpri                   ! grid mean for wet deposition (pri)
+real,      INTENT(IN)                            :: gemwdsec                   ! grid mean for wet deposition (sec)
+real,      INTENT(IN)                            :: totwdep                    ! grid total wet deposition (g/s)
+real,      INTENT(IN)                            :: wdrpri                     ! effective wet deposition rate (primary component) [%/h]
+real,      INTENT(IN)                            :: wdrsec                     ! effective wet deposition rate (secondary component) [%/h]
+real,      INTENT(IN)                            :: gemprec                    ! grid mean annual precpitation from meteo
+real,      INTENT(IN)                            :: gemtdep                    ! grid mean for total deposition
+real,      INTENT(IN)                            :: tottdep                    ! grid total total deposition
+real,      INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary substance [ug/m3]
+real,      INTENT(IN)                            :: gem_subsec(nsubsec)        ! grid mean for concentration of sub-secondary species [ug/m3]
 CHARACTER*(*), INTENT(IN)                        :: nam_subsec(nsubsec)        ! names of sub-secondary species
-REAL*4,    INTENT(IN)                            :: totdep(nrrcp)              ! total deposition
-REAL*4,    INTENT(IN)                            :: scale_con                  ! scalefactor prim. concentration
-REAL*4,    INTENT(IN)                            :: scale_sec                  ! scalefactor sec. concentration
-REAL*4,    INTENT(IN)                            :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
-REAL*4,    INTENT(IN)                            :: scale_dep                  ! scalefactor deposition
+real,      INTENT(IN)                            :: totdep(nrrcp)              ! total deposition
+real,      INTENT(IN)                            :: scale_con                  ! scalefactor prim. concentration
+real,      INTENT(IN)                            :: scale_sec                  ! scalefactor sec. concentration
+real,      INTENT(IN)                            :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
+real,      INTENT(IN)                            :: scale_dep                  ! scalefactor deposition
 
 ! SUBROUTINE ARGUMENTS - I/O
 LOGICAL,   INTENT(INOUT)                         :: idep                       ! deposition taken into account
@@ -121,7 +121,7 @@ TYPE (TError), INTENT(OUT)                       :: error                      !
 
 ! LOCAL VARIABLES
 INTEGER                                          :: j                          ! counter through receptro points
-REAL*4                                           :: tmp(nrrcp)                 ! tempory array with values to be written
+real                                             :: tmp(nrrcp)                 ! tempory array with values to be written
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
 
 

--- a/ops_print_info.f90
+++ b/ops_print_info.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME                  : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE      : %B% - %S%
 ! DATE - TIME           : %E% - %U%
 ! WHAT                  : %W%:%E%
-! AUTHOR                :
+! AUTHOR                : OPS-support 
 ! FIRM/INSTITUTE        : RIVM/LLO
 ! LANGUAGE              : FORTRAN-77/90
 ! DESCRIPTION           : Prints input parameters at the end of text output

--- a/ops_print_info.f90
+++ b/ops_print_info.f90
@@ -58,24 +58,24 @@ LOGICAL,   INTENT(IN)                            :: gasv                       !
 LOGICAL,   INTENT(IN)                            :: isec                       ! true when comp=SO2,NOx,NH3
 INTEGER*4, INTENT(IN)                            :: intpol                     ! 
 INTEGER*4, INTENT(IN)                            :: spgrid                     ! code for type of receptor points
-REAL*4,    INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
+real,      INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
 CHARACTER*(*), INTENT(IN)                        :: namco                      ! substance name
 INTEGER*4, INTENT(IN)                            :: nbron                      ! number of emission sources (after selection)
 INTEGER*4, INTENT(IN)                            :: bnr(LSBUF)                 ! buffer with source numbers
 INTEGER*4, INTENT(IN)                            :: bx(LSBUF)                  ! buffer with x-coordinates
 INTEGER*4, INTENT(IN)                            :: by(LSBUF)                  ! buffer with y-coordinates
-REAL*4,    INTENT(IN)                            :: bsterkte(LSBUF)            ! buffer with source strengths (industrial)
-REAL*4,    INTENT(IN)                            :: bqrv(LSBUF)                ! buffer with source strengths (space heating)
-REAL*4,    INTENT(IN)                            :: bqtr(LSBUF)                ! buffer with source strengths (traffic)
-REAL*4,    INTENT(IN)                            :: bwarmte(LSBUF)             ! buffer with heat contents
-REAL*4,    INTENT(IN)                            :: bhoogte(LSBUF)             ! buffer with source heights
-REAL*4,    INTENT(IN)                            :: bdiam(LSBUF)               ! buffer with source diameters
-REAL*4,    INTENT(IN)                            :: bsigmaz(LSBUF)             ! buffer with source heigth variances
+real,      INTENT(IN)                            :: bsterkte(LSBUF)            ! buffer with source strengths (industrial)
+real,      INTENT(IN)                            :: bqrv(LSBUF)                ! buffer with source strengths (space heating)
+real,      INTENT(IN)                            :: bqtr(LSBUF)                ! buffer with source strengths (traffic)
+real,      INTENT(IN)                            :: bwarmte(LSBUF)             ! buffer with heat contents
+real,      INTENT(IN)                            :: bhoogte(LSBUF)             ! buffer with source heights
+real,      INTENT(IN)                            :: bdiam(LSBUF)               ! buffer with source diameters
+real,      INTENT(IN)                            :: bsigmaz(LSBUF)             ! buffer with source heigth variances
 INTEGER*4, INTENT(IN)                            :: btgedr(LSBUF)              ! buffer with diurnal variation codes
 INTEGER*4, INTENT(IN)                            :: bdegr(LSBUF)               ! buffer with particle size distribution codes
 INTEGER*4, INTENT(IN)                            :: bcatnr(LSBUF)              ! buffer with category codes
 INTEGER*4, INTENT(IN)                            :: blandnr(LSBUF)             ! buffer with area codes
-REAL*4,    INTENT(IN)                            :: emtrend                    ! emission correction factor
+real,      INTENT(IN)                            :: emtrend                    ! emission correction factor
 INTEGER*4, INTENT(IN)                            :: jb                         ! starting year of meteo
 INTEGER*4, INTENT(IN)                            :: mb                         ! starting month of meteo
 INTEGER*4, INTENT(IN)                            :: idb                        ! starting day of meteo
@@ -86,7 +86,7 @@ INTEGER*4, INTENT(IN)                            :: iseiz                      !
 LOGICAL*4, INTENT(IN)                            :: f_z0user                   ! true if z0 is user specified
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: emis(6,NLANDMAX)
+real,      INTENT(INOUT)                         :: emis(6,NLANDMAX)
 INTEGER*4, INTENT(INOUT)                         :: landmax                    ! number of countries in emission file
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
@@ -101,7 +101,7 @@ INTEGER*4                                        :: ierr                       !
 INTEGER*4                                        :: indx                       ! 
 INTEGER*4                                        :: jndx                       ! 
 INTEGER*4                                        :: statclass                  ! 
-REAL*4                                           :: qb                         ! emission of individual source
+real                                             :: qb                         ! emission of individual source
 CHARACTER*1                                      :: statcode                   ! 
 CHARACTER*30                                     :: climper(0:6)               ! 
 

--- a/ops_print_kop.f90
+++ b/ops_print_kop.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-F77/90
 ! DESCRIPTION        : Print page header ("kop"= head)

--- a/ops_print_recep.f90
+++ b/ops_print_recep.f90
@@ -65,47 +65,47 @@ CHARACTER*(*), INTENT(IN)                        :: namsec                     !
 CHARACTER*(*), INTENT(IN)                        :: namse3                     ! 
 CHARACTER*(*), INTENT(IN)                        :: coneh                      ! 
 CHARACTER*(*), INTENT(IN)                        :: depeh                      ! 
-REAL*4,    INTENT(IN)                            :: conc_cf                    ! 
-REAL*4,    INTENT(IN)                            :: amol21                     ! 
-REAL*4,    INTENT(IN)                            :: ugmoldep                   ! 
+real,      INTENT(IN)                            :: conc_cf
+real,      INTENT(IN)                            :: amol21
+real,      INTENT(IN)                            :: ugmoldep
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptor points
 INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species
 CHARACTER*(*), INTENT(IN)                        :: namrcp (nrrcp)             ! 
-REAL*4,    INTENT(IN)                            :: xm(nrrcp)                  ! 
-REAL*4,    INTENT(IN)                            :: ym(nrrcp)                  ! 
-REAL*4,    INTENT(IN)                            :: precip(nrrcp)              ! calculated precipitation
-REAL*4,    INTENT(IN)                            :: cpri(nrrcp)                ! primary concentration
-REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! secondary concentration
-REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! dry deposition
-REAL*4,    INTENT(IN)                            :: ddepri(nrrcp)              ! dry depo of primary comp.
-REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! wet deposition
-REAL*4,    INTENT(IN)                            :: rno2_nox_sum(nrrcp)        ! NO2/NOx ratio, weighed sum over classes
+real,      INTENT(IN)                            :: xm(nrrcp)
+real,      INTENT(IN)                            :: ym(nrrcp)
+real,      INTENT(IN)                            :: precip(nrrcp)              ! calculated precipitation
+real,      INTENT(IN)                            :: cpri(nrrcp)                ! primary concentration
+real,      INTENT(IN)                            :: csec(nrrcp)                ! secondary concentration
+real,      INTENT(IN)                            :: drydep(nrrcp)              ! dry deposition
+real,      INTENT(IN)                            :: ddepri(nrrcp)              ! dry depo of primary comp.
+real,      INTENT(IN)                            :: wetdep(nrrcp)              ! wet deposition
+real,      INTENT(IN)                            :: rno2_nox_sum(nrrcp)        ! NO2/NOx ratio, weighed sum over classes
 INTEGER*4, INTENT(IN)                            :: lu_rcp_dom_all(nrrcp)      ! 
-REAL*4,    INTENT(IN)                            :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
-REAL*4,    INTENT(IN)                            :: gemcpri                    ! mean for prim. concentration
-REAL*4,    INTENT(IN)                            :: gemcsec                    ! mean for sec. concentration
-REAL*4,    INTENT(IN)                            :: ccr                        ! eff. chemical conversion rate
-REAL*4,    INTENT(IN)                            :: gemddep                    ! mean for dry deposition
-REAL*4,    INTENT(IN)                            :: gemddpri                   ! mean for dry deposition (pri)
-REAL*4,    INTENT(IN)                            :: gemddsec                   ! mean for dry deposition (sec)
-REAL*4,    INTENT(IN)                            :: ddrpri                     ! eff. dry deposition rate (prim)
-REAL*4,    INTENT(IN)                            :: ddrsec                     ! eff. dry deposition rate (sec)
-REAL*4,    INTENT(IN)                            :: gemwdep                    ! mean for wet deposition
-REAL*4,    INTENT(IN)                            :: gemwdpri                   ! mean for wet deposition (pri)
-REAL*4,    INTENT(IN)                            :: gemwdsec                   ! mean for wet deposition (sec)
-REAL*4,    INTENT(IN)                            :: wdrpri                     ! eff. wet deposition rate (prim)
-REAL*4,    INTENT(IN)                            :: wdrsec                     ! eff. wet deposition rate (sec)
-REAL*4,    INTENT(IN)                            :: gemprec                    ! mean annual precpitation from meteo
-REAL*4,    INTENT(IN)                            :: gemtdep                    ! mean for total deposition
+real,      INTENT(IN)                            :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
+real,      INTENT(IN)                            :: gemcpri                    ! mean for prim. concentration
+real,      INTENT(IN)                            :: gemcsec                    ! mean for sec. concentration
+real,      INTENT(IN)                            :: ccr                        ! eff. chemical conversion rate
+real,      INTENT(IN)                            :: gemddep                    ! mean for dry deposition
+real,      INTENT(IN)                            :: gemddpri                   ! mean for dry deposition (pri)
+real,      INTENT(IN)                            :: gemddsec                   ! mean for dry deposition (sec)
+real,      INTENT(IN)                            :: ddrpri                     ! eff. dry deposition rate (prim)
+real,      INTENT(IN)                            :: ddrsec                     ! eff. dry deposition rate (sec)
+real,      INTENT(IN)                            :: gemwdep                    ! mean for wet deposition
+real,      INTENT(IN)                            :: gemwdpri                   ! mean for wet deposition (pri)
+real,      INTENT(IN)                            :: gemwdsec                   ! mean for wet deposition (sec)
+real,      INTENT(IN)                            :: wdrpri                     ! eff. wet deposition rate (prim)
+real,      INTENT(IN)                            :: wdrsec                     ! eff. wet deposition rate (sec)
+real,      INTENT(IN)                            :: gemprec                    ! mean annual precpitation from meteo
+real,      INTENT(IN)                            :: gemtdep                    ! mean for total deposition
 INTEGER*4, INTENT(IN)                            :: icm                        ! number of component
-REAL*4,    INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
-REAL*4,    INTENT(IN)                            :: gem_subsec(nsubsec)        ! grid mean for concentration of sub-secondary species [ug/m3]
+real,      INTENT(IN)                            :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary species [ug/m3]
+real,      INTENT(IN)                            :: gem_subsec(nsubsec)        ! grid mean for concentration of sub-secondary species [ug/m3]
 CHARACTER*(*), INTENT(IN)                        :: nam_subsec(nsubsec)        ! names of sub-secondary speciea
-REAL*4,    INTENT(IN)                            :: totdep(nrrcp)              ! total deposition
-REAL*4,    INTENT(IN)                            :: scale_con                  ! 
-REAL*4,    INTENT(IN)                            :: scale_sec                  ! 
-REAL*4,    INTENT(IN)                            :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
-REAL*4,    INTENT(IN)                            :: scale_dep                  ! 
+real,      INTENT(IN)                            :: totdep(nrrcp)              ! total deposition
+real,      INTENT(IN)                            :: scale_con
+real,      INTENT(IN)                            :: scale_sec
+real,      INTENT(IN)                            :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
+real,      INTENT(IN)                            :: scale_dep
 
 ! SUBROUTINE ARGUMENTS - I/O
 LOGICAL,   INTENT(INOUT)                         :: idep                       ! 
@@ -118,13 +118,13 @@ TYPE (Terror), INTENT(INOUT)                     :: error                      !
 INTEGER*4                                        :: i                          ! 
 INTEGER*4                                        :: j                          ! 
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
-REAL*4                                           :: scalec                     ! 
-REAL*4                                           :: scaled                     ! 
-REAL*4                                           :: scalen                     ! 
-REAL*4                                           :: scalsc                     ! 
-REAL*4                                           :: vdpri(nrrcp)               ! 
-REAL*4                                           :: vdsec(nrrcp)               ! 
-REAL*4                                           :: tmp(nrrcp)                 ! dry+wet deposition
+real                                             :: scalec
+real                                             :: scaled
+real                                             :: scalen
+real                                             :: scalsc
+real                                             :: vdpri(nrrcp)
+real                                             :: vdsec(nrrcp)
+real                                             :: tmp(nrrcp)                 ! dry+wet deposition
 CHARACTER*4                                      :: vdeh                       ! 
 CHARACTER*4                                      :: z0eh                       ! 
 CHARACTER*4                                      :: lueh                       ! 

--- a/ops_print_table.f90
+++ b/ops_print_table.f90
@@ -147,36 +147,36 @@ PARAMETER    (ROUTINENAAM = 'print_values')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! 
 CHARACTER*(*), INTENT(IN)                        :: namrcp(nrrcp)              ! 
-REAL*4,    INTENT(IN)                            :: xm(nrrcp)                  ! 
-REAL*4,    INTENT(IN)                            :: ym(nrrcp)                  ! 
-REAL*4,    INTENT(IN), OPTIONAL                  :: par1(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar1                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par2(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar2                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par3(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar3                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par4(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar4                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par5(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar5                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par6(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar6                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par7(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar7                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par8(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar8                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par9(nrrcp)                ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar9                      ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par10(nrrcp)               ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar10                     ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par11(nrrcp)               ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar11                     ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par12(nrrcp)               ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar12                     ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par13(nrrcp)               ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar13                     ! factor in parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: par14(nrrcp)               ! values of parameter
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar14                     ! factor in parameter
+real,      INTENT(IN)                            :: xm(nrrcp)
+real,      INTENT(IN)                            :: ym(nrrcp)
+real,      INTENT(IN), OPTIONAL                  :: par1(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar1                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par2(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar2                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par3(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar3                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par4(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar4                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par5(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar5                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par6(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar6                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par7(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar7                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par8(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar8                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par9(nrrcp)                ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar9                      ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par10(nrrcp)               ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar10                     ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par11(nrrcp)               ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar11                     ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par12(nrrcp)               ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar12                     ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par13(nrrcp)               ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar13                     ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: par14(nrrcp)               ! values of parameter
+real,      INTENT(IN), OPTIONAL                  :: spar14                     ! factor in parameter
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! should not happen as format string is long enough
@@ -185,8 +185,8 @@ TYPE (TError), INTENT(INOUT)                     :: error                      !
 INTEGER*4                                        :: i                          ! 
 INTEGER*4                                        :: j                          ! 
 INTEGER*4                                        :: values(nrparam)            ! 
-REAL*4                                           :: factors(nrparam)           ! 
-REAL*4                                           :: factorscopy(nrparam)       ! 
+real                                             :: factors(nrparam)
+real                                             :: factorscopy(nrparam)
 INTEGER*4                                        :: nrpresent                  ! 
 INTEGER*4                                        :: nrunit                     ! 
 LOGICAL                                          :: dummybool                  ! 
@@ -299,11 +299,11 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'has_rcp_values')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN), OPTIONAL                  :: spar                       ! factor in parameter
+real,      INTENT(IN), OPTIONAL                  :: spar                       ! factor in parameter
 
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT(INOUT)                         :: nrpresent                  ! 
-REAL*4,    INTENT(INOUT)                         :: factors(:)                 ! 
+real,      INTENT(INOUT)                         :: factors(:)
 
 has_rcp_values = PRESENT(spar)
 IF (has_rcp_values) THEN
@@ -325,8 +325,8 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'set_rcp_values')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: formatpar                  ! 
-REAL*4,    INTENT(IN)                            :: factors(nrpresent)         ! 
+real,      INTENT(IN)                            :: formatpar
+real,      INTENT(IN)                            :: factors(nrpresent)
 INTEGER*4, INTENT(IN)                            :: nrpresent                  ! 
 
 ! SUBROUTINE ARGUMENTS - I/O

--- a/ops_print_table.f90
+++ b/ops_print_table.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME                : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE   : %B% - %S%
 ! DATE - TIME         : %E% - %U%
 ! WHAT                : %W%:%E%
-! AUTHOR              : Martien de Haan (ARIS)
+! AUTHOR              : OPS-support   
 ! FIRM/INSTITUTE      : RIVM/LLO
 ! LANGUAGE            : FORTRAN-77/90
 ! DESCRIPTION         : Subroutines supporting receptor point printing.
@@ -64,7 +67,7 @@ CONTAINS
 ! SUBROUTINE: print_conc_names
 ! PURPOSE:    prints names of concentration parameters
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE  print_conc_names(namco, namsec, namseccor)
+SUBROUTINE  print_conc_names(namco, namsec, nam_subsec)
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -73,18 +76,20 @@ PARAMETER    (ROUTINENAAM = 'print_conc_names')
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: namco                      ! 
 CHARACTER*(*), INTENT(IN), OPTIONAL              :: namsec                     ! 
-CHARACTER*(*), INTENT(IN), OPTIONAL              :: namseccor                  ! 
+CHARACTER*(*), INTENT(IN), OPTIONAL              :: nam_subsec(:)              ! names of sub-secondary species
 
+! Local variable
+INTEGER                                          :: isubsec                    ! index of sub-secondary species
 !-------------------------------------------------------------------------------------------------------------------------------
 !
 ! FORMATS
 !
-700 FORMAT (/' Concentrations for ',a:,' and ',a:,' and ',a:)
+700 FORMAT (/' Concentrations for ',9(1x,a))
 701 FORMAT (/' Concentrations for ',a:,' and ',a:)
 702 FORMAT (/' Concentrations for ',a:)
 
-IF (PRESENT(namseccor)) THEN
-   WRITE(fu_prt, 700) namco(1:LEN_TRIM(namco)), namsec(:LEN_TRIM(namsec)), namseccor(:LEN_TRIM(namseccor))
+IF (PRESENT(nam_subsec)) THEN
+   WRITE(fu_prt, 700) namco(1:LEN_TRIM(namco)), namsec(:LEN_TRIM(namsec)), (nam_subsec(isubsec)(:LEN_TRIM(nam_subsec(isubsec))), isubsec = 1,size(nam_subsec))
 ELSEIF (PRESENT(namsec)) THEN
    WRITE(fu_prt, 701) namco(1:LEN_TRIM(namco)), namsec(:LEN_TRIM(namsec))
 ELSE
@@ -126,14 +131,14 @@ END SUBROUTINE print_depo_names
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE: print_values
 ! PURPOSE:    prints values at all the receptor points for certain parameters. The parameters and even their numbers are
-!             variable (up to 12 currently, but this can easily be increased).
+!             variable (up to 14 currently, but this can easily be increased).
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE  print_values    (nrrcp, namrcp, xm, ym, error, par1, spar1, par2, spar2, par3, spar3, par4, spar4, par5, spar5,    &
                              &  par6, spar6, par7, spar7, par8, spar8, par9, spar9, par10, spar10, par11, spar11, par12,       &
-                             &  spar12)
+                             &  spar12, par13, spar13, par14, spar14)
 
 INTEGER                                          :: nrparam                    ! 
-PARAMETER (nrparam = 12)
+PARAMETER (nrparam = 14)
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -168,6 +173,10 @@ REAL*4,    INTENT(IN), OPTIONAL                  :: par11(nrrcp)               !
 REAL*4,    INTENT(IN), OPTIONAL                  :: spar11                     ! factor in parameter
 REAL*4,    INTENT(IN), OPTIONAL                  :: par12(nrrcp)               ! values of parameter
 REAL*4,    INTENT(IN), OPTIONAL                  :: spar12                     ! factor in parameter
+REAL*4,    INTENT(IN), OPTIONAL                  :: par13(nrrcp)               ! values of parameter
+REAL*4,    INTENT(IN), OPTIONAL                  :: spar13                     ! factor in parameter
+REAL*4,    INTENT(IN), OPTIONAL                  :: par14(nrrcp)               ! values of parameter
+REAL*4,    INTENT(IN), OPTIONAL                  :: spar14                     ! factor in parameter
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! should not happen as format string is long enough
@@ -182,9 +191,9 @@ INTEGER*4                                        :: nrpresent                  !
 INTEGER*4                                        :: nrunit                     ! 
 LOGICAL                                          :: dummybool                  ! 
 
-CHARACTER*120                                    :: formatpar                  ! format in writing parameter names
-CHARACTER*120                                    :: formatval                  ! format in writing parameter values
-CHARACTER*120                                    :: formatunit                 ! format in writing parameter units
+CHARACTER*180                                    :: formatpar                  ! format in writing parameter names
+CHARACTER*180                                    :: formatval                  ! format in writing parameter values
+CHARACTER*180                                    :: formatunit                 ! format in writing parameter units
 !
 ! Create factors array and determine nrpresent.
 !
@@ -196,7 +205,8 @@ dummybool = has_rcp_values(spar1, nrpresent, factors) .AND. has_rcp_values(spar2
    &  .AND. has_rcp_values(spar5, nrpresent, factors) .AND. has_rcp_values(spar6, nrpresent, factors)                          &
    &  .AND. has_rcp_values(spar7, nrpresent, factors) .AND. has_rcp_values(spar8, nrpresent, factors)                          &
    &  .AND. has_rcp_values(spar9, nrpresent, factors) .AND. has_rcp_values(spar10, nrpresent, factors)                         &
-   &  .AND. has_rcp_values(spar11, nrpresent, factors) .AND. has_rcp_values(spar12, nrpresent, factors)
+   &  .AND. has_rcp_values(spar11, nrpresent, factors) .AND. has_rcp_values(spar12, nrpresent, factors)                        &
+   &  .AND. has_rcp_values(spar13, nrpresent, factors) .AND. has_rcp_values(spar14, nrpresent, factors)
 !
 ! Create the factorscopy, where only factors unequal to 1 are counted.
 ! Determine nrunit and create formatstrings that depends upon the factors.
@@ -251,6 +261,10 @@ DO i = 1, nrrcp
                     IF (set_rcp_values(par10(i), factors, nrpresent, j, values)) THEN
                       IF (set_rcp_values(par11(i), factors, nrpresent, j, values)) THEN
                         IF (set_rcp_values(par12(i), factors, nrpresent, j, values)) THEN
+                           IF (set_rcp_values(par13(i), factors, nrpresent, j, values)) THEN
+                              IF (set_rcp_values(par14(i), factors, nrpresent, j, values)) THEN
+                              ENDIF
+                           ENDIF
                         ENDIF
                       ENDIF
                     ENDIF

--- a/ops_rcp_char_1.f90
+++ b/ops_rcp_char_1.f90
@@ -59,32 +59,32 @@ LOGICAL*4, INTENT(IN)                            :: isec
 INTEGER*4, INTENT(IN)                            :: ircp                   
 INTEGER*4, INTENT(IN)                            :: nrrcp   
 INTEGER*4, INTENT(IN)                            :: intpol                     ! 
-REAL*4,    INTENT(IN)                            :: gxm_rcp                    ! array met x-coordinaat van receptorpunten (lola)
-REAL*4,    INTENT(IN)                            :: gym_rcp                    ! array met y-coordinaat van receptorpunten (lola)
-REAL*4,    INTENT(IN)                            :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG) ! 
-REAL*4,    INTENT(IN)                            :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
-REAL*4,    INTENT(IN)                            :: xreg(NMETREG)              ! array met x-coordinaat van meteo-regios
-REAL*4,    INTENT(IN)                            :: yreg(NMETREG)              ! array met y-coordinaat van meteo-regio's
-REAL*4,    INTENT(IN)                            :: z0_metreg_user             ! roughness length of user specified meteo region [m]
+real,      INTENT(IN)                            :: gxm_rcp                    ! array met x-coordinaat van receptorpunten (lola)
+real,      INTENT(IN)                            :: gym_rcp                    ! array met y-coordinaat van receptorpunten (lola)
+real,      INTENT(IN)                            :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)
+real,      INTENT(IN)                            :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
+real,      INTENT(IN)                            :: xreg(NMETREG)              ! array met x-coordinaat van meteo-regios
+real,      INTENT(IN)                            :: yreg(NMETREG)              ! array met y-coordinaat van meteo-regio's
+real,      INTENT(IN)                            :: z0_metreg_user             ! roughness length of user specified meteo region [m]
 INTEGER*4, INTENT(IN)                            :: spgrid
-REAL*4,    INTENT(IN)                            :: x_rcp                      ! array met x-coordinaat van receptorpunten (RDM)
-REAL*4,    INTENT(IN)                            :: y_rcp                      ! array met y-coordinaat van receptorpunten (RDM)
+real,      INTENT(IN)                            :: x_rcp                      ! array met x-coordinaat van receptorpunten (RDM)
+real,      INTENT(IN)                            :: y_rcp                      ! array met y-coordinaat van receptorpunten (RDM)
 TYPE (TApsGridInt), INTENT(IN)                   :: lugrid                     ! grid with land use information
 LOGICAL*4, INTENT(IN)                            :: domlu                      ! index of dominant land use class
 LOGICAL*4, INTENT(IN)                            :: perc                           ! 
 INTEGER,   INTENT(IN)                            :: lu_rcp_per_user_all(nrrcp,NLU) ! percentage of landuse for all receptors, used defined in receptor file
 INTEGER*4, INTENT(IN)                            :: lu_rcp_dom_all(nrrcp)      ! land use at receptor points
 LOGICAL*4, INTENT(IN)                            :: f_z0user                   
-REAL*4,    INTENT(IN)                            :: z0_rcp_all(nrrcp)                 ! roughness lengths for all receptors; from z0-map or receptor file [m]
+real,      INTENT(IN)                            :: z0_rcp_all(nrrcp)                 ! roughness lengths for all receptors; from z0-map or receptor file [m]
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT (INOUT)                        :: i1(NTRAJ-1)                ! 
-REAL*4,    INTENT(INOUT)                         :: astat(NTRAJ,NCOMP,NSTAB,NSEK) ! 
+real,      INTENT(INOUT)                         :: astat(NTRAJ,NCOMP,NSTAB,NSEK)
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uurtot                     ! 
-REAL*4,    INTENT(OUT)                           :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
+real,      INTENT(OUT)                           :: uurtot
+real,      INTENT(OUT)                           :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
 INTEGER*4, INTENT(OUT)                           :: lu_rcp_dom                 ! dominant landuse class for receptor
-REAL*4,    INTENT(OUT)                           :: lu_rcp_per(NLU)            ! percentages of landuse classes at receptor points
-REAL*4,    INTENT(OUT)                           :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
+real,      INTENT(OUT)                           :: lu_rcp_per(NLU)            ! percentages of landuse classes at receptor points
+real,      INTENT(OUT)                           :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
 TYPE (TError)                                    :: error  
 
 ! LOCAL VARIABLES
@@ -201,20 +201,20 @@ INTEGER*4                                        :: NONZERO(NCOMP)             !
                                                                                ! frequency of occurrence
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: x                          ! x-coordinate (longitude; degrees)
-REAL*4,    INTENT(IN)                            :: y                          ! y-coordinate (latitude; degrees)
-REAL*4,    INTENT(IN)                            :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG) ! 
-REAL*4,    INTENT(IN)                            :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
-REAL*4,    INTENT(IN)                            :: xreg(NMETREG)              ! x-coordinate region centre (longitude; degrees)
-REAL*4,    INTENT(IN)                            :: yreg(NMETREG)              ! y-coordinate region centre (latitude; degrees)
+real,      INTENT(IN)                            :: x                          ! x-coordinate (longitude; degrees)
+real,      INTENT(IN)                            :: y                          ! y-coordinate (latitude; degrees)
+real,      INTENT(IN)                            :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)
+real,      INTENT(IN)                            :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
+real,      INTENT(IN)                            :: xreg(NMETREG)              ! x-coordinate region centre (longitude; degrees)
+real,      INTENT(IN)                            :: yreg(NMETREG)              ! y-coordinate region centre (latitude; degrees)
 
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT(INOUT)                         :: i1(NTRAJ-1)                ! indices of three regions nearest to the receptor
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: z0_metreg_xy               ! roughness length at (x,y), interpolated from meteo regions [m]
-REAL*4,    INTENT(OUT)                           :: uurtot                     ! 
-REAL*4,    INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
+real,      INTENT(OUT)                           :: z0_metreg_xy               ! roughness length at (x,y), interpolated from meteo regions [m]
+real,      INTENT(OUT)                           :: uurtot
+real,      INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
@@ -224,18 +224,18 @@ INTEGER*4                                        :: istab                      !
 INTEGER*4                                        :: imin                       ! index of nearest region
 INTEGER*4                                        :: itraj                      ! index of distance class
 INTEGER*4                                        :: isek                       ! index of wind sector
-REAL*4                                           :: a                          ! Set a = cos(y); needed in computation of distance
+real                                             :: a                          ! Set a = cos(y); needed in computation of distance
                                                                                ! dx = (x2 - x1)*cos(y) for geographical coordinates
 
-REAL*4                                           :: r                          ! distance region - receptor
-REAL*4                                           :: rmin                       ! distance nearest region - receptor
-REAL*4                                           :: s                          ! sum of s1()
-REAL*4                                           :: ss                         ! 
-REAL*4                                           :: rr                         ! 
-REAL*4                                           :: rrtot                      ! 
-REAL*4                                           :: r1(NTRAJ-1)                ! distance of three nearest regions - receptor
-REAL*4                                           :: s1(NTRAJ-1)                ! inverse distance = 1/r1()
-REAL*4                                           :: ss1(NTRAJ-1)               ! 
+real                                             :: r                          ! distance region - receptor
+real                                             :: rmin                       ! distance nearest region - receptor
+real                                             :: s                          ! sum of s1()
+real                                             :: ss
+real                                             :: rr
+real                                             :: rrtot
+real                                             :: r1(NTRAJ-1)                ! distance of three nearest regions - receptor
+real                                             :: s1(NTRAJ-1)                ! inverse distance = 1/r1()
+real                                             :: ss1(NTRAJ-1)
 
 ! DATA
 !            1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27

--- a/ops_rcp_char_1.f90
+++ b/ops_rcp_char_1.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Prepares values for landuse and roughness for one receptorpoint.
@@ -35,7 +38,7 @@
 ! CALLED FUNCTIONS   :
 ! UPDATE HISTORY :
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_rcp_char_1(ircp, nrrcp, intpol, gxm_rcp, gym_rcp, cs, z0_metreg, xreg, yreg, i1, astat, z0_metreg_user,            &
+SUBROUTINE ops_rcp_char_1(isec, ircp, nrrcp, intpol, gxm_rcp, gym_rcp, cs, z0_metreg, xreg, yreg, i1, astat, z0_metreg_user,    &
                        &  spgrid, x_rcp, y_rcp, lugrid, domlu, perc, lu_rcp_per_user_all, lu_rcp_dom_all, f_z0user, z0_rcp_all, &
                        &  uurtot, z0_metreg_rcp, lu_rcp_per, lu_rcp_dom, z0_rcp, error)
 
@@ -52,7 +55,8 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_rcp_char_1')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-INTEGER*4, INTENT(IN)                            :: ircp                        
+LOGICAL*4, INTENT(IN)                            :: isec                        
+INTEGER*4, INTENT(IN)                            :: ircp                   
 INTEGER*4, INTENT(IN)                            :: nrrcp   
 INTEGER*4, INTENT(IN)                            :: intpol                     ! 
 REAL*4,    INTENT(IN)                            :: gxm_rcp                    ! array met x-coordinaat van receptorpunten (lola)
@@ -116,10 +120,12 @@ IF (ANY(spgrid == (/0,1/))) THEN
 ! ---   Fill lu_rcp_per array with info from standard grid with landuse info
 ! ---   The first aps-grid contains dominant landuse so we start with the second
 !
-    DO lu=2,NLU+1
-      CALL GridValue(x_rcp/1000, y_rcp/1000, lugrid, lu_rcp_per_int(lu-1), iscell, lu)
-    ENDDO     
-    lu_rcp_per = float(lu_rcp_per_int)
+    IF (isec) THEN
+      DO lu=2,NLU+1
+        CALL GridValue(x_rcp/1000, y_rcp/1000, lugrid, lu_rcp_per_int(lu-1), iscell, lu)
+      ENDDO     
+      lu_rcp_per = float(lu_rcp_per_int)
+    ENDIF
   ENDIF
 ELSE
   IF (.not.perc) THEN
@@ -127,10 +133,12 @@ ELSE
 ! ---   User did not specify percentages landuse in rcp-file.
 ! ---   Fill lu_rcp_per array with info from standard grid with landuse info
 !
-    DO lu=2,NLU+1
-      CALL GridValue(x_rcp/1000, y_rcp/1000, lugrid, lu_rcp_per_int(lu-1), iscell, lu)
-    ENDDO     
-    lu_rcp_per = float(lu_rcp_per_int)
+    IF (isec) THEN
+      DO lu=2,NLU+1
+        CALL GridValue(x_rcp/1000, y_rcp/1000, lugrid, lu_rcp_per_int(lu-1), iscell, lu)
+      ENDDO     
+      lu_rcp_per = float(lu_rcp_per_int)
+    ENDIF
   ELSE
 !
 ! ---   User specified percentages landuse in rcp-file.

--- a/ops_rcp_char_all.f90
+++ b/ops_rcp_char_all.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Fill arrays with receptor characteristics:
@@ -36,12 +39,13 @@
 ! CALLED FUNCTIONS   : amcgeo, ops_getz0, ops_getlu, ops_bgcon
 ! UPDATE HISTORY :
 !-------------------------------------------------------------------------------------------------------------------------------
-subroutine ops_rcp_char_all(icm, isec, xm, ym, f_z0user, z0_user, z0nlgrid, z0eurgrid, lugrid, so2bggrid, nh3bggrid,  &
-                          & nrrcp, gxm, gym, lu_rcp_dom_all, z0_rcp_all, rhno3_rcp, nh3bg_rcp, domlu, error)
+subroutine ops_rcp_char_all(icm, iopt_vchem, isec, nsubsec, xm, ym, f_z0user, z0_user, z0nlgrid, z0eurgrid, lugrid, so2bggrid, nh3bggrid, f_subsec_grid, &
+                          & nrrcp, gxm, gym, lu_rcp_dom_all, z0_rcp_all, rhno3_rcp, nh3bg_rcp, so2bg_rcp, f_subsec_rcp, domlu, error)
 
 USE m_aps
 USE m_geoutils
 USE m_commonconst
+USE m_ops_bgcon
 USE m_error
 
 IMPLICIT NONE
@@ -52,7 +56,9 @@ PARAMETER    (ROUTINENAAM = 'ops_rcp_char_all')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: icm                        
+INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)
 LOGICAL*4, INTENT(IN)                            :: isec                       
+INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species                       
 REAL*4,    INTENT(IN)                            :: xm(nrrcp)                  ! x-coordinates of receptors
 REAL*4,    INTENT(IN)                            :: ym(nrrcp)                  ! y-coordinates of receptors
 LOGICAL*4, INTENT(IN)                            :: f_z0user                   
@@ -60,8 +66,9 @@ REAL*4,    INTENT(IN)                            :: z0_user                    !
 TYPE (TApsGridInt), INTENT(IN)                   :: z0nlgrid                   ! map of roughness lengths in NL [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: z0eurgrid                  ! map of roughness lengths in Europe [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: lugrid                     ! grid with land use information
-TYPE (TApsGridReal), INTENT(IN)                  :: so2bggrid                  ! 
-TYPE (TApsGridReal), INTENT(IN)                  :: nh3bggrid                  ! 
+TYPE (TApsGridReal), INTENT(IN)                  :: so2bggrid                  ! grid of SO2 background concentrations [ug/m3]
+TYPE (TApsGridReal), INTENT(IN)                  :: nh3bggrid                  ! grid of NH3 background concentrations [ug/m3]
+TYPE (TApsGridReal), INTENT(IN)                  :: f_subsec_grid              ! grids of fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptors
 LOGICAL*4, INTENT(IN)                            :: domlu                      ! index of dominant land use class
 
@@ -70,21 +77,25 @@ REAL*4,    INTENT(OUT)                           :: gxm(nrrcp)
 REAL*4,    INTENT(OUT)                           :: gym(nrrcp)                  
 REAL*4,    INTENT(OUT)                           :: rhno3_rcp(nrrcp)           
 REAL*4,    INTENT(OUT)                           :: nh3bg_rcp(nrrcp)
+REAL*4,    INTENT(OUT)                           :: so2bg_rcp(nrrcp)
+REAL*4,    INTENT(OUT)                           :: f_subsec_rcp(nrrcp,nsubsec)   ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
 
-! SUBROUTINE ARGUMENTS - INPUT/OUTPUT
+! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4                                        :: landuse(NLU+1)             ! land-use value at receptor
                                                                                ! landuse(1)    = index of dominant landuse
                                                                                ! landuse(lu+1) = percentage of grid cell with landuse class lu, lu = 1,NLU
                                                                                ! For locations outside lugrid, a default land use class = 1 (grass) is taken.
 INTEGER*4, INTENT(INOUT)                         :: lu_rcp_dom_all(nrrcp)      ! index of dominant land use for all receptor points             
 REAL*4,    INTENT(INOUT)                         :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
-TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record 
+TYPE (TError), INTENT(INOUT)                     :: error   
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: ircp                       ! index of receptor
+INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
 REAL*4                                           :: so2bgconc                  ! background concentratie SO2
 REAL*4                                           :: nh3bgconc                  ! background concentration NH3 at receptor [ppb]
 LOGICAL                                          :: z0found                    
+INTEGER                                          :: ifield                     ! field index in f_subsec_grid
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -125,14 +136,14 @@ DO ircp = 1, nrrcp
       ENDIF
     ENDIF
   ENDIF
-!
-! Get background concentrations at receptor
-!
-  IF (isec) THEN
 
+! For SO2, NOx, NH3:
+IF (isec) THEN
+
+    ! Get background concentrations at receptor
     CALL ops_bgcon(xm(ircp),ym(ircp),nh3bggrid, nh3bgconc)
-
-!
+!   Distribute NO3 and SO4 into sub-secondary species
+! 
 !   rhno3 = ratio [HNO3]/[NO3]_total (NO3_total = HNO3+NO3_aerosol); all concentrations in ppb.
 !
 !                  [NH3]_background   -0.44
@@ -146,17 +157,51 @@ DO ircp = 1, nrrcp
 !   Note that for background [NH3] = 0.346 ppb, rhno3_rcp = 0.024*(nh3bgconc/1000)**(-0.44) = 0.8
 !             for background [NH3] < 0.346 ppb, rhno3_rcp is fixed at 0.8.
 !
+!   Note that we still use rhno3_rcp for computing weighed averaged Rc-values; later on, this must be replaced by f_subsec_rcp.
+!   For distributing concentrations over different secondary species, we use f_subsec_rcp, which is read from file.
+!
     IF (icm == 2) THEN
       rhno3_rcp(ircp)=amin1(0.024*(nh3bgconc/1000)**(-0.44),0.8) 
-    ENDIF
+      
+      ! Get fractions for different sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total at current receptor location:
+      if (iopt_vchem .eq. 0) then  
+  
+         ! File with f_subsec_grid is not present, use old OPS parameterisation rhno3 and do not split into coarse and fine:
+         !WdV f_subsec_rcp(ircp,1) = rhno3_rcp(ircp)                           ! HNO3
+         !WdV f_subsec_rcp(ircp,2) = (1.0 - rhno3_rcp(ircp))                   ! NO3_AEROSOL
+         f_subsec_rcp(ircp,1) = (1.0 - rhno3_rcp(ircp))                   ! NO3_AEROSOL
+         f_subsec_rcp(ircp,2) = rhno3_rcp(ircp)                           ! HNO3
+
+         ! for NO3-coarse and - fine, fractions are used from BOP-report 
+         ! f_subsec_rcp(ircp,2) = frac_no3c_bop*(1.0 - rhno3_rcp(ircp))   ! NO3_C
+         ! f_subsec_rcp(ircp,3) = frac_no3f_bop*(1.0 - rhno3_rcp(ircp))   ! NO3_F
+      else
+         ! Get fraction from EMEP grid:
+         ! (3 fields in f_subsec_grid: HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total; 4 sub species NO3_aerosol, HNO3, NO3_C, NO3_F)
+         do isubsec = 2,nsubsec
+            ifield = isubsec - 1 
+            CALL ops_bgcon(xm(ircp),ym(ircp),f_subsec_grid, f_subsec_rcp(ircp,isubsec),ifield)
+         enddo
+         
+         ! Fraction NO3_aerosol / NO3_total:
+         f_subsec_rcp(ircp,1) = f_subsec_rcp(ircp,3) + f_subsec_rcp(ircp,4)  
+      endif
+    ELSE
 !    
-!   Convert NH3 background concentration from ppb to ug/m3 (is used as such in DEPAC)
+!     Convert NH3 background concentration from ppb to ug/m3 (is used as such in DEPAC)
 !
-    nh3bg_rcp(ircp)=nh3bgconc*17/24
-  
+      nh3bg_rcp(ircp)=nh3bgconc*17/24
+!
+!     Get so2 background concentration at receptor
+!
+      CALL ops_bgcon(xm(ircp),ym(ircp),so2bggrid, so2bgconc)
+!    
+!     Convert SO2 background concentration from ppb to ug/m3 (is used as such in DEPAC)
+!
+      so2bg_rcp(ircp)=so2bgconc*64./24. 
+    ENDIF
   ENDIF
-  
-  if (error%debug) write(*,'(3a,1x,i6,99(1x,e12.5))') trim(ROUTINENAAM),',A,',' ircp,z0_rcp_all(ircp),lu_rcp_dom_all(ircp),nh3bg_rcp(ircp): ', &
+  IF (error%debug) WRITE(*,'(3a,1x,i6,99(1x,e12.5))') trim(ROUTINENAAM),',A,',' ircp,z0_rcp_all(ircp),lu_rcp_dom_all(ircp),nh3bg_rcp(ircp): ', &
                                                                                 ircp,z0_rcp_all(ircp),lu_rcp_dom_all(ircp),nh3bg_rcp(ircp)
 ENDDO
 

--- a/ops_rcp_char_all.f90
+++ b/ops_rcp_char_all.f90
@@ -59,10 +59,10 @@ INTEGER*4, INTENT(IN)                            :: icm
 INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)
 LOGICAL*4, INTENT(IN)                            :: isec                       
 INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species                       
-REAL*4,    INTENT(IN)                            :: xm(nrrcp)                  ! x-coordinates of receptors
-REAL*4,    INTENT(IN)                            :: ym(nrrcp)                  ! y-coordinates of receptors
+real,      INTENT(IN)                            :: xm(nrrcp)                  ! x-coordinates of receptors
+real,      INTENT(IN)                            :: ym(nrrcp)                  ! y-coordinates of receptors
 LOGICAL*4, INTENT(IN)                            :: f_z0user                   
-REAL*4,    INTENT(IN)                            :: z0_user                    ! roughness length specified by user [m]
+real,      INTENT(IN)                            :: z0_user                    ! roughness length specified by user [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: z0nlgrid                   ! map of roughness lengths in NL [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: z0eurgrid                  ! map of roughness lengths in Europe [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: lugrid                     ! grid with land use information
@@ -73,12 +73,12 @@ INTEGER*4, INTENT(IN)                            :: nrrcp                      !
 LOGICAL*4, INTENT(IN)                            :: domlu                      ! index of dominant land use class
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: gxm(nrrcp)                 
-REAL*4,    INTENT(OUT)                           :: gym(nrrcp)                  
-REAL*4,    INTENT(OUT)                           :: rhno3_rcp(nrrcp)           
-REAL*4,    INTENT(OUT)                           :: nh3bg_rcp(nrrcp)
-REAL*4,    INTENT(OUT)                           :: so2bg_rcp(nrrcp)
-REAL*4,    INTENT(OUT)                           :: f_subsec_rcp(nrrcp,nsubsec)   ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
+real,      INTENT(OUT)                           :: gxm(nrrcp)
+real,      INTENT(OUT)                           :: gym(nrrcp)
+real,      INTENT(OUT)                           :: rhno3_rcp(nrrcp)
+real,      INTENT(OUT)                           :: nh3bg_rcp(nrrcp)
+real,      INTENT(OUT)                           :: so2bg_rcp(nrrcp)
+real,      INTENT(OUT)                           :: f_subsec_rcp(nrrcp,nsubsec)   ! fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4                                        :: landuse(NLU+1)             ! land-use value at receptor
@@ -86,14 +86,14 @@ INTEGER*4                                        :: landuse(NLU+1)             !
                                                                                ! landuse(lu+1) = percentage of grid cell with landuse class lu, lu = 1,NLU
                                                                                ! For locations outside lugrid, a default land use class = 1 (grass) is taken.
 INTEGER*4, INTENT(INOUT)                         :: lu_rcp_dom_all(nrrcp)      ! index of dominant land use for all receptor points             
-REAL*4,    INTENT(INOUT)                         :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
+real,      INTENT(INOUT)                         :: z0_rcp_all(nrrcp)          ! roughness lengths for all receptors; from z0-map or receptor file [m]
 TYPE (TError), INTENT(INOUT)                     :: error   
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: ircp                       ! index of receptor
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
-REAL*4                                           :: so2bgconc                  ! background concentratie SO2
-REAL*4                                           :: nh3bgconc                  ! background concentration NH3 at receptor [ppb]
+real                                             :: so2bgconc                  ! background concentratie SO2
+real                                             :: nh3bgconc                  ! background concentration NH3 at receptor [ppb]
 LOGICAL                                          :: z0found                    
 INTEGER                                          :: ifield                     ! field index in f_subsec_grid
 

--- a/ops_read_bg.f90
+++ b/ops_read_bg.f90
@@ -73,12 +73,12 @@ INTEGER*4                                        :: j                          !
 INTEGER*4                                        :: mapnumber                  ! number of background map
 INTEGER*4                                        :: ji                         ! year index, i.e. the index in the trendfactor 
                                                                                ! arrays tf_... of the current year
-REAL*4                                           :: factor                     ! combined correction factor (calibration with 
+real                                             :: factor                     ! combined correction factor (calibration with
                                                                                ! measurements and correction for year)
 LOGICAL*1                                        :: future                     ! TRUE if year is closer to FUTUREYEAR than to last
                                                                                ! historic year
-REAL*4                                           :: nox_threshold              ! threshold value for NOx in log-function in NOx -> NO2 conversion
-REAL*4                                           :: alpha                      ! slope of linear function NOx -> NO2 conversion
+real                                             :: nox_threshold              ! threshold value for NOx in log-function in NOx -> NO2 conversion
+real                                             :: alpha                      ! slope of linear function NOx -> NO2 conversion
 INTEGER                                          :: i1                         ! index of yyyy in filename
 CHARACTER*128                                    :: fnam                       ! filename
 TYPE (TApsGridReal)                              :: qq                         ! test grid output
@@ -305,20 +305,20 @@ if (iopt_vchem .eq. 1) then
    !  !  character*10      modversie
    !  !  character*12      kname
    !  !  character*(*)     namegr          ! name of grid file (used for error message)
-   !  !
+   !
    !  !  character*12      quantity
    !  !subroutine saveaps(coord_sys,lu,namegr,xorg,yorg,gridx,gridy,matx,maty,cpri,namco,unit_conc,modversie,kname,quantity,ijg,img,idg,iug)
    !  call saveaps('RDM',34,'qq0',qq%gridheader%xorgl,qq%gridheader%yorgl,qq%gridheader%grixl,qq%gridheader%griyl,qq%gridheader%nrcol,qq%gridheader%nrrow,qq%value(:,:,1),'conv_rate ','%/h     ','OPS_tst   ','qq1         ','qq2         ',10,0,0,0)
    !  close(34)
    !  !!     TYPE TGridHeader
-   !  !!    REAL*4                                        :: xorgl                      ! x-origin of the grid [km]
+   !  !!    real                                          :: xorgl                      ! x-origin of the grid [km]
    !  !!                                                                                ! (origin is left-upper corner of grid)
-   !  !!    REAL*4                                        :: yorgl                      ! y-origin of the grid [km]
+   !  !!    real                                          :: yorgl                      ! y-origin of the grid [km]
    !  !!                                                                                ! (origin is left-upper corner of grid)
    !  !!    INTEGER*4                                     :: nrcol                      ! number of grid columns
    !  !!    INTEGER*4                                     :: nrrow                      ! number of grid rows
-   !  !!    REAL*4                                        :: grixl                      ! horizontal size of grid cell [km]
-   !  !!    REAL*4                                        :: griyl                      ! vertical size of grid cell [km]
+   !  !!    real                                          :: grixl                      ! horizontal size of grid cell [km]
+   !  !!    real                                          :: griyl                      ! vertical size of grid cell [km]
    !  !! END TYPE TGridHeader
    ! ! END TEST write to APS file --------------------------------------------------------------------------------------------
    

--- a/ops_read_bg.f90
+++ b/ops_read_bg.f90
@@ -1,21 +1,25 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!-------------------------------------------------------------------------------------------------------------------------------
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! FILENAME           : %M%
@@ -24,7 +28,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : Hans van Jaarveld/Martien de Haan
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO/IS
 ! LANGUAGE           : FORTRAN(HP-UX, HP-F77, HP-F90)
 ! DESCRIPTION        : Handling of background concentrations.
@@ -39,23 +43,28 @@
 ! Purpose      Reads background concentrations for SO2, NO2 and NH3.
 !              Called only when isec is set (icm = 1, 2 or 3).
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_read_bg(icm, year, so2bggrid, no2bggrid, nh3bggrid, error)
+SUBROUTINE ops_read_bg(icm, iopt_vchem, nsubsec, year, so2bggrid, no2bggrid, nh3bggrid, f_subsec_grid, vchem2, error)
 
 USE m_aps
 USE m_error
 USE m_commonconst
 USE m_commonfile
+USE m_ops_vchem
 
 IMPLICIT NONE
 
 ! SUBROUTINE ARGUMENTS - INPUT
-INTEGER*4, INTENT(IN)                            :: icm                        
+INTEGER*4, INTENT(IN)                            :: icm                        ! substance index
+INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)
+INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number of sub-secondary species                       
 INTEGER*4, INTENT(IN)                            :: year                       ! year under consideration
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 TYPE (TApsGridReal), INTENT(OUT)                 :: so2bggrid                  ! grid with SO2 background concentration [ppb]
 TYPE (TApsGridReal), INTENT(OUT)                 :: no2bggrid                  ! grid with NO2 background concentration [ppb]
 TYPE (TApsGridReal), INTENT(OUT)                 :: nh3bggrid                  ! grid with NH3 background concentration [ppb]
+TYPE (TApsGridReal), INTENT(OUT)                 :: f_subsec_grid              ! grids of fractions for sub-secondary species, HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total [-]
+TYPE (Tvchem),       INTENT(INOUT)               :: vchem2                     ! 
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
@@ -70,7 +79,13 @@ LOGICAL*1                                        :: future                     !
                                                                                ! historic year
 REAL*4                                           :: nox_threshold              ! threshold value for NOx in log-function in NOx -> NO2 conversion
 REAL*4                                           :: alpha                      ! slope of linear function NOx -> NO2 conversion
-
+INTEGER                                          :: i1                         ! index of yyyy in filename
+CHARACTER*128                                    :: fnam                       ! filename
+TYPE (TApsGridReal)                              :: qq                         ! test grid output
+INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
+CHARACTER*512                                    :: apsfile                    ! full file name of APS-file to read
+INTEGER                                          :: nfield                     ! number of fields in file with NO3-distribution grids (f_subsec_grid)
+INTEGER                                          :: ifield                     ! field number in f_subsec_grid
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
@@ -202,6 +217,114 @@ IF (error%haserror) GOTO 9999
 !
 factor = 24./17. * cf_nh3(mapnumber) * tf_nh3(ji)
 CALL SetAverage(factor, nh3bggrid)
+
+! iopt_vchem = 1 -> read EMEP grids with column averaged masses and mass converted [ug/m2] used for chemical conversion rate vchem:
+if (iopt_vchem .eq. 1) then
+   ! Read MASS_PRE for this year from file 'xxx_mass_prec_yyyy.ops'; xxx = name primary species (SO2, NOx, NH3), yyyy = year (e.g. 2019):
+   fnam = map_mass_prec
+   write(fnam(1:3),'(A3)') CNAME(icm,1)
+   i1 = index(fnam,'yyyy');
+   write(fnam(i1:i1+3),'(I4)') year
+   CALL read_bg_file(trim(fnam),'mass precursor', vchem2%mass_prec_grid, error)
+   if (error%haserror) GOTO 9999
+ 
+   call SetAverage(grid = vchem2%mass_prec_grid) 
+ 
+   ! Read MASS_CONV_DTFAC for this year:
+   fnam = map_mass_conv_dtfac
+   write(fnam(1:3),'(A3)') CNAME(icm,1)
+   i1 = index(fnam,'yyyy');
+   write(fnam(i1:i1+3),'(I4)') year
+   CALL read_bg_file(trim(fnam),'(100/dt) * mass converted chemistry', vchem2%mass_conv_dtfac_grid, error)
+   if (error%haserror) GOTO 9999
+ 
+   call SetAverage(grid = vchem2%mass_conv_dtfac_grid)  
+ 
+   ! write(*,*) 'average of mass_prec_grid: ', vchem2%mass_prec_grid%average            
+   ! write(*,*) 'average of mass_conv_dtfac_grid: ', vchem2%mass_conv_dtfac_grid%average
+   ! write(*,*) 'average conversion rate [%/h]: ', vchem2%mass_conv_dtfac_grid%average/vchem2%mass_prec_grid%average 
+   
+   ! Read distribution maps for NO3_total: HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total;
+   ! from file 'no3_distr_yyyy.ops'; yyyy = year (e.g. 2019)
+   if (icm .eq. 2) then
+      fnam = map_no3_distr
+      i1 = index(fnam,'yyyy');
+      write(fnam(i1:i1+3),'(I4)') year
+
+      ! Prepend datadir and check if file exists:
+      call MakeCommonPath(fnam, apsfile, error)
+      if (error%haserror) goto 9999
+
+      ! Read fractions for sub-secondary species:
+      ! write(*,*) 'reading fractions NO3 from file ',trim(apsfile)  
+      CALL read_bg_file(trim(fnam),'fractions of NO3' , f_subsec_grid, error)
+      if (error%haserror) GOTO 9999
+      
+      ! Get number of fields in f_subsec_grid; should be equal to nsubsec-1 
+      ! (3 fields HNO3/NO3_total, NO3_C/NO3_total, NO3_F/NO3_total; 4 sub species NO3_aerosol, HNO3, NO3_C, NO3_F)
+      nfield = size(f_subsec_grid%value,3)
+      ! WdV write(*,'(a,i6)')  '--------------- number of fields read in ops_read_bg ----------------- : ',nfield
+      if (nfield .ne. nsubsec-1) then
+         write(*,'(/,/,a)') 'internal programming error'
+         write(*,'(a,a)')   'incorrect number of fields in file ',trim(fnam)
+         write(*,'(a,i6)')  'number of fields read: ',nfield
+         write(*,'(a,i6)')  'number of sub species: ',nsubsec
+         write(*,'(a)')     'number of fields must be equal to number of sub species - 1: '
+         stop
+      endif
+
+      ! Set average of grid (is used in ops_bgcon for missing (negative) values or values outside grid):
+      do ifield = 1,nfield
+         call SetAverage(grid = f_subsec_grid, fieldnumber = ifield)
+         ! write(*,*) 'average of grid of secondary component ',ifield,' = ',f_subsec_grid%average(ifield) 
+      enddo
+   endif
+
+   ! ! START TEST write to APS file --------------------------------------------------------------------------------------------
+   !  qq%gridheader%xorgl = 1000*vchem2%mass_prec_grid(1)%gridheader%xorgl
+   !  qq%gridheader%yorgl = 1000*vchem2%mass_prec_grid(1)%gridheader%yorgl
+   !  qq%gridheader%grixl = 1000*vchem2%mass_prec_grid(1)%gridheader%grixl
+   !  qq%gridheader%griyl = 1000*vchem2%mass_prec_grid(1)%gridheader%griyl
+   !  qq%gridheader%nrcol = vchem2%mass_prec_grid(1)%gridheader%nrcol
+   !  qq%gridheader%nrrow = vchem2%mass_prec_grid(1)%gridheader%nrrow
+   !  allocate(qq%value(qq%gridheader%nrcol, qq%gridheader%nrrow, 1))
+   !  qq%value = vchem2%mass_conv_dtfac_grid(1)%value/vchem2%mass_prec_grid(1)%value
+   !  write(*,*) 'grid for conversion factor'
+   !  open(unit = 34, file = 'cvr_tst1.aps')
+   !  !
+   !  !
+   !  !  character*(*)     coord_sys       ! coordinate system, either 'RDM' or 'lon-lat'
+   !  !  integer           lu
+   !  !  real              xorg, yorg
+   !  !  real              gridx,gridy
+   !  !  integer           matx,maty
+   !  !  integer           ijg,img,idg,iug
+   !  !  real*4            cpri(matx,maty)
+   !  !  character*8       unit_conc
+   !  !  character*10      namco
+   !  !  character*10      modversie
+   !  !  character*12      kname
+   !  !  character*(*)     namegr          ! name of grid file (used for error message)
+   !  !
+   !  !  character*12      quantity
+   !  !subroutine saveaps(coord_sys,lu,namegr,xorg,yorg,gridx,gridy,matx,maty,cpri,namco,unit_conc,modversie,kname,quantity,ijg,img,idg,iug)
+   !  call saveaps('RDM',34,'qq0',qq%gridheader%xorgl,qq%gridheader%yorgl,qq%gridheader%grixl,qq%gridheader%griyl,qq%gridheader%nrcol,qq%gridheader%nrrow,qq%value(:,:,1),'conv_rate ','%/h     ','OPS_tst   ','qq1         ','qq2         ',10,0,0,0)
+   !  close(34)
+   !  !!     TYPE TGridHeader
+   !  !!    REAL*4                                        :: xorgl                      ! x-origin of the grid [km]
+   !  !!                                                                                ! (origin is left-upper corner of grid)
+   !  !!    REAL*4                                        :: yorgl                      ! y-origin of the grid [km]
+   !  !!                                                                                ! (origin is left-upper corner of grid)
+   !  !!    INTEGER*4                                     :: nrcol                      ! number of grid columns
+   !  !!    INTEGER*4                                     :: nrrow                      ! number of grid rows
+   !  !!    REAL*4                                        :: grixl                      ! horizontal size of grid cell [km]
+   !  !!    REAL*4                                        :: griyl                      ! vertical size of grid cell [km]
+   !  !! END TYPE TGridHeader
+   ! ! END TEST write to APS file --------------------------------------------------------------------------------------------
+   
+   IF (error%haserror) GOTO 9999
+endif
+
 ! 
 RETURN
 !
@@ -222,7 +345,7 @@ USE m_string
 
 ! SUBROUTINE ARGUMENTS - INPUT
 CHARACTER*(*), INTENT(IN)                        :: filename                   ! name of file to read background concentration from
-CHARACTER*(*), INTENT(IN)                        :: compname                   ! component name for which to read background concentration
+CHARACTER*(*), INTENT(IN)                        :: compname                   ! component name for which to read background concentration (used in error message only)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 TYPE (TApsGridReal), INTENT(OUT)                 :: bggrid                     ! background concentration grid

--- a/ops_read_ctr.f90
+++ b/ops_read_ctr.f90
@@ -58,31 +58,31 @@ CHARACTER*(*), INTENT(OUT)                       :: runid                      !
 INTEGER*4, INTENT(OUT)                           :: year                       ! year under consideration
 INTEGER*4, INTENT(OUT)                           :: icm                        
 CHARACTER*(*), INTENT(OUT)                       :: namco                      
-REAL*4,    INTENT(OUT)                           :: amol1                      
+real,      INTENT(OUT)                           :: amol1
 LOGICAL,   INTENT(OUT)                           :: gasv                       ! type of component (0: particle; 1: gas)
 LOGICAL,   INTENT(OUT)                           :: idep                       
 INTEGER*4, INTENT(OUT)                           :: kdeppar                    
-REAL*4,    INTENT(OUT)                           :: ddeppar                    
+real,      INTENT(OUT)                           :: ddeppar
 INTEGER*4, INTENT(OUT)                           :: knatdeppar                 
-REAL*4,    INTENT(OUT)                           :: wdeppar                    
-REAL*4,    INTENT(OUT)                           :: dg                         
+real,      INTENT(OUT)                           :: wdeppar
+real,      INTENT(OUT)                           :: dg
 LOGICAL,   INTENT(OUT)                           :: irev                       
-REAL*4,    INTENT(OUT)                           :: vchemc                     ! chemical conversion rate [%/h]
+real,      INTENT(OUT)                           :: vchemc                     ! chemical conversion rate [%/h]
 INTEGER*4, INTENT(OUT)                           :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)
-REAL*4,    INTENT(OUT)                           :: vchemv                     
-REAL*4,    INTENT(OUT)                           :: emtrend                    
+real,      INTENT(OUT)                           :: vchemv
+real,      INTENT(OUT)                           :: emtrend
 INTEGER*4, INTENT(OUT)                           :: ncatsel                    
 INTEGER*4, INTENT(OUT)                           :: catsel(*)                  
 INTEGER*4, INTENT(OUT)                           :: nlandsel                   
 INTEGER*4, INTENT(OUT)                           :: landsel(*)                 
 INTEGER*4, INTENT(OUT)                           :: spgrid                     
-REAL*4,    INTENT(OUT)                           :: xc                         ! x-coordinate grid centre of user specified grid (spgrid = 1)
-REAL*4,    INTENT(OUT)                           :: yc                         ! y-coordinate grid centre of user specified grid (spgrid = 1)
+real,      INTENT(OUT)                           :: xc                         ! x-coordinate grid centre of user specified grid (spgrid = 1)
+real,      INTENT(OUT)                           :: yc                         ! y-coordinate grid centre of user specified grid (spgrid = 1)
 INTEGER*4, INTENT(OUT)                           :: nrcol                      
 INTEGER*4, INTENT(OUT)                           :: nrrow                      
-REAL*4,    INTENT(OUT)                           :: grid                       ! grid resolution [m]
+real,      INTENT(OUT)                           :: grid                       ! grid resolution [m]
 LOGICAL,   INTENT(OUT)                           :: igrens                     
-REAL*4,    INTENT(OUT)                           :: z0_user                    ! roughness length specified by user [m]
+real,      INTENT(OUT)                           :: z0_user                    ! roughness length specified by user [m]
 INTEGER*4, INTENT(OUT)                           :: intpol                     
 INTEGER*4, INTENT(OUT)                           :: ideh                       
 LOGICAL,   INTENT(OUT)                           :: igrid                      
@@ -93,8 +93,8 @@ INTEGER*4, INTENT(OUT)                           :: nsubsec                    !
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
-REAL*4                                           :: lower                      ! lower limit (is used for checking variables read) 
-REAL*4                                           :: upper                      ! upper limit (is used for checking variables read) 
+real                                             :: lower                      ! lower limit (is used for checking variables read)
+real                                             :: upper                      ! upper limit (is used for checking variables read)
 CHARACTER*(512)                                  :: str1                       ! string value read from control file
 
 ! SCCS-ID VARIABLES

--- a/ops_read_emis.f90
+++ b/ops_read_emis.f90
@@ -70,10 +70,10 @@ TYPE (TError), INTENT(INOUT)                     :: error                      !
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: numbron                    ! number of selected sources
-REAL*4,    INTENT(OUT)                           :: dverl(NHRBLOCKS,MAXDISTR)  ! standard diurnal emission variations distributions
-REAL*4,    INTENT(OUT)                           :: usdverl(NHRBLOCKS,MAXDISTR)! user-defined diurnal emission variations distributions
-REAL*4,    INTENT(OUT)                           :: pmd(NPARTCLASS,MAXDISTR)   ! standard particle size distributions
-REAL*4,    INTENT(OUT)                           :: uspmd(NPARTCLASS,MAXDISTR) ! user-defined particle size distributions
+real,      INTENT(OUT)                           :: dverl(NHRBLOCKS,MAXDISTR)  ! standard diurnal emission variations distributions
+real,      INTENT(OUT)                           :: usdverl(NHRBLOCKS,MAXDISTR)! user-defined diurnal emission variations distributions
+real,      INTENT(OUT)                           :: pmd(NPARTCLASS,MAXDISTR)   ! standard particle size distributions
+real,      INTENT(OUT)                           :: uspmd(NPARTCLASS,MAXDISTR) ! user-defined particle size distributions
 INTEGER*4, INTENT(OUT)                           :: dv                         ! maximum code diurnal emission variation dverl
 INTEGER*4, INTENT(OUT)                           :: usdv                       ! maximum code user specified diurnal emission variation usdverl
 LOGICAL,   INTENT(OUT)                           :: presentcode(MAXDISTR,4)    ! which distribution codes are present
@@ -185,13 +185,13 @@ CHARACTER*(*), INTENT(IN)                        :: compdesc                   !
 LOGICAL,   INTENT(IN)                            :: fraction                   ! whether conversion to fractions is required (instead of %)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: distrib(nrclass,MAXDISTR)   ! array with all distributions 
+real,      INTENT(OUT)                           :: distrib(nrclass,MAXDISTR)   ! array with all distributions
 INTEGER*4, INTENT(OUT)                           :: maxcode                    ! maximum code used for distribution
 LOGICAL,   INTENT(OUT)                           :: presentcode(MAXDISTR)       ! which distribution codes are present
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
-INTEGER*4                                        :: distcode                   ! code used for distribution; 
+INTEGER*4                                        :: distcode                   ! code used for distribution;
                                                                                ! read from the first column of the distributions file.
                                                                                ! (|distcode| = index into 2nd dimension of distrib(nclass, MAXDISTR))
 
@@ -199,9 +199,9 @@ INTEGER*4                                        :: distcode                   !
 INTEGER*4                                        :: i                          ! DO LOOP counter
 INTEGER*4                                        :: numdist                    ! Number of distributions read
 INTEGER*4                                        :: ierr                       ! value of IOSTAT
-REAL*4                                           :: buffer(nrclass)            ! array with the last distrib values read
-REAL*4                                           :: som                        ! sum of row values
-REAL*4                                           :: normalfactor               ! normalisation factor
+real                                             :: buffer(nrclass)            ! array with the last distrib values read
+real                                             :: som                        ! sum of row values
+real                                             :: normalfactor               ! normalisation factor
 CHARACTER*80                                     :: readformat                 ! format used for reading
 LOGICAL                                          :: ops_openlog                ! function for opening log file
 

--- a/ops_read_emis.f90
+++ b/ops_read_emis.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE      : %B% - %S%
 ! DATE - TIME           : %E% - %U%
 ! WHAT                  : %W%:%E%
-! AUTHOR                :
+! AUTHOR                : OPS-support 
 ! FIRM/INSTITUTE        : RIVM/LLO
 ! LANGUAGE              : FORTRAN-77/90
 ! DESCRIPTION           : Read source file with emissions and files with diurnal emission variations and particle size distributions.
@@ -161,7 +164,7 @@ CONTAINS
 ! +002    33    33    35    80   150   155   120   116   122   135   145    77 Average heating behaviour
 ! +003    24    16    23   150   175   121   127   154   190   112    60    48 Average traffic intensity
 
-! Example of particle size distribution file:
+! Example of particle size distribution file: FS
 ! 
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE read_variation(distnam, fmt, nrclass, normalvalue, compdesc, fraction, distrib, maxcode, presentcode, error)

--- a/ops_read_meteo.f90
+++ b/ops_read_meteo.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             :
+! AUTHOR             : OPS-support 
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Read meteo statistics.

--- a/ops_read_meteo.f90
+++ b/ops_read_meteo.f90
@@ -438,7 +438,7 @@ CHARACTER*(*), INTENT(IN)                        :: nfile                      !
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*2, INTENT(OUT)                           :: ishort(NSTAB*NSEK)         ! meta data of meteo statistics file
-REAL*4,    INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK) 
+real,      INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES

--- a/ops_read_meteo.f90
+++ b/ops_read_meteo.f90
@@ -64,28 +64,28 @@ INTEGER*4, INTENT(OUT)                           :: idb
 INTEGER*4, INTENT(OUT)                           :: jt                          
 INTEGER*4, INTENT(OUT)                           :: mt                          
 INTEGER*4, INTENT(OUT)                           :: idt                         
-REAL*4,    INTENT(OUT)                           :: uurtot                      
+real,      INTENT(OUT)                           :: uurtot
 INTEGER*4, INTENT(OUT)                           :: iseiz                       
-REAL*4,    INTENT(OUT)                           :: zf                          
-REAL*4,    INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)  
-REAL*4,    INTENT(OUT)                           :: trafst(NTRAJ)               
-REAL*4,    INTENT(OUT)                           :: gemre                       
-REAL*4,    INTENT(OUT)                           :: z0_metreg_user             ! roughness length of user specified meteo region [m]
-REAL*4,    INTENT(OUT)                           :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)  
-REAL*4,    INTENT(OUT)                           :: rainreg(NMETREG)            
-REAL*4,    INTENT(OUT)                           :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]     
-REAL*4,    INTENT(OUT)                           :: xreg(NMETREG)               
-REAL*4,    INTENT(OUT)                           :: yreg(NMETREG)               
-REAL*4,    INTENT(OUT)                           :: hourreg(NMETREG)            
+real,      INTENT(OUT)                           :: zf
+real,      INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(OUT)                           :: trafst(NTRAJ)
+real,      INTENT(OUT)                           :: gemre
+real,      INTENT(OUT)                           :: z0_metreg_user             ! roughness length of user specified meteo region [m]
+real,      INTENT(OUT)                           :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)
+real,      INTENT(OUT)                           :: rainreg(NMETREG)
+real,      INTENT(OUT)                           :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
+real,      INTENT(OUT)                           :: xreg(NMETREG)
+real,      INTENT(OUT)                           :: yreg(NMETREG)
+real,      INTENT(OUT)                           :: hourreg(NMETREG)
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: iyr                        ! year of time stamp of meteo file; currently not used
 INTEGER*4                                        :: imon                       ! month of time stamp of meteo file; currently not used
 INTEGER*4                                        :: iday                       ! day of time stamp of meteo file; currently not used
-REAL*4                                           :: xpos                        
-REAL*4                                           :: ypos                        
-REAL*4                                           :: z0_metreg1                 ! rougness length of 1 meteo region [m]                        
+real                                             :: xpos
+real                                             :: ypos
+real                                             :: z0_metreg1                 ! rougness length of 1 meteo region [m]
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -131,8 +131,8 @@ USE m_error
 IMPLICIT NONE
 
 ! CONSTANTS
-REAL*4                                           :: XP(NMETREG)                ! x-coordinate meteo regions in NL
-REAL*4                                           :: YP(NMETREG)                ! y-coordinate meteo regions in NL
+real                                             :: XP(NMETREG)                ! x-coordinate meteo regions in NL
+real                                             :: YP(NMETREG)                ! y-coordinate meteo regions in NL
                                                                                ! (XP,YP)~ centre of circle that encompasses a meteo region.
                                                                                ! (XP,YP) are used for interpolation of meteo parameters in a 
                                                                                ! specific location
@@ -146,17 +146,17 @@ INTEGER*4, INTENT(OUT)                           :: idb
 INTEGER*4, INTENT(OUT)                           :: jt                          
 INTEGER*4, INTENT(OUT)                           :: mt                          
 INTEGER*4, INTENT(OUT)                           :: idt                         
-REAL*4,    INTENT(OUT)                           :: uurtot                      
+real,      INTENT(OUT)                           :: uurtot
 INTEGER*4, INTENT(OUT)                           :: iseiz                       
-REAL*4,    INTENT(OUT)                           :: zf                          
-REAL*4,    INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)  
-REAL*4,    INTENT(OUT)                           :: trafst(NTRAJ)               
-REAL*4,    INTENT(OUT)                           :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG) 
-REAL*4,    INTENT(OUT)                           :: rainreg(NMETREG)            
-REAL*4,    INTENT(OUT)                           :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]     
-REAL*4,    INTENT(OUT)                           :: xreg(NMETREG)               
-REAL*4,    INTENT(OUT)                           :: yreg(NMETREG)               
-REAL*4,    INTENT(OUT)                           :: hourreg(NMETREG)            
+real,      INTENT(OUT)                           :: zf
+real,      INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(OUT)                           :: trafst(NTRAJ)
+real,      INTENT(OUT)                           :: cs(NTRAJ, NCOMP, NSTAB, NSEK, NMETREG)
+real,      INTENT(OUT)                           :: rainreg(NMETREG)
+real,      INTENT(OUT)                           :: z0_metreg(NMETREG)         ! roughness lengths of NMETREG meteo regions; scale < 50 km [m]
+real,      INTENT(OUT)                           :: xreg(NMETREG)
+real,      INTENT(OUT)                           :: yreg(NMETREG)
+real,      INTENT(OUT)                           :: hourreg(NMETREG)
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES
@@ -165,10 +165,10 @@ INTEGER*4                                        :: iday                       !
 INTEGER*4                                        :: imon                       ! month of time stamp of meteo file; currently not used
 INTEGER*4                                        :: iyr                        ! year of time stamp of meteo file; currently not used
 INTEGER                                          :: idx                        ! index of '.' in name of meteo statistics file
-REAL*4                                           :: gemre                      ! average amount of precipitation (mm/h)
-REAL*4                                           :: xpos                       
-REAL*4                                           :: ypos                       
-REAL*4                                           :: z0_metreg1                 ! roughness length of 1 meteo region [m]                      
+real                                             :: gemre                      ! average amount of precipitation (mm/h)
+real                                             :: xpos
+real                                             :: ypos
+real                                             :: z0_metreg1                 ! roughness length of 1 meteo region [m]
 CHARACTER*512                                    :: nfile                      ! filename for meteo statistics file
 
 ! DATA 
@@ -259,21 +259,21 @@ CHARACTER*(*), INTENT(IN)                        :: nfile                      !
 INTEGER*4, INTENT(OUT)                           :: jb                         ! start year (meteo statistics period) ("b" << begin = start)
 INTEGER*4, INTENT(OUT)                           :: mb                         ! start month (meteo statistics period) ("b" << begin = start)
 INTEGER*4, INTENT(OUT)                           :: idb                        ! start day (meteo statistics period) ("b" << begin = start)
-REAL*4,    INTENT(OUT)                           :: gemre                      ! average precipitation amount [mm/h]
+real,      INTENT(OUT)                           :: gemre                      ! average precipitation amount [mm/h]
 INTEGER*4, INTENT(OUT)                           :: iyr                        ! year of time stamp of meteo file; currently not used
 INTEGER*4, INTENT(OUT)                           :: imon                       ! month of time stamp of meteo file; currently not used
 INTEGER*4, INTENT(OUT)                           :: iday                       ! day of time stamp of meteo file; currently not used
-REAL*4,    INTENT(OUT)                           :: xpos                       
-REAL*4,    INTENT(OUT)                           :: ypos                       
-REAL*4,    INTENT(OUT)                           :: z0_metreg1                 ! rougness length of 1 meteo region [m]                        
+real,      INTENT(OUT)                           :: xpos
+real,      INTENT(OUT)                           :: ypos
+real,      INTENT(OUT)                           :: z0_metreg1                 ! rougness length of 1 meteo region [m]
 INTEGER*4, INTENT(OUT)                           :: jt                         ! end year (meteo statistics period) ("t" << tot = until)
 INTEGER*4, INTENT(OUT)                           :: mt                         ! end month (meteo statistics period) ("t" << tot = until)
 INTEGER*4, INTENT(OUT)                           :: idt                        ! end day (meteo statistics period) ("t" << tot = until)
-REAL*4,    INTENT(OUT)                           :: uurtot                     ! total number of hours ("uur" = hour)
+real,      INTENT(OUT)                           :: uurtot                     ! total number of hours ("uur" = hour)
 INTEGER*4, INTENT(OUT)                           :: iseiz                      
-REAL*4,    INTENT(OUT)                           :: zf                          
-REAL*4,    INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK) 
-REAL*4,    INTENT(OUT)                           :: trafst(NTRAJ)               
+real,      INTENT(OUT)                           :: zf
+real,      INTENT(OUT)                           :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(OUT)                           :: trafst(NTRAJ)
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES

--- a/ops_read_source.f90
+++ b/ops_read_source.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 !
@@ -25,7 +28,7 @@
 ! BRANCH -SEQUENCE      : %B% - %S%
 ! DATE - TIME           : %E% - %U%
 ! WHAT                  : %W%:%E%
-! AUTHOR                :
+! AUTHOR                : OPS-support 
 ! FIRM/INSTITUTE        : RIVM/LLO
 ! LANGUAGE              : FORTRAN-77/90
 ! DESCRIPTION           : Read source file with emissions.

--- a/ops_read_source.f90
+++ b/ops_read_source.f90
@@ -85,13 +85,13 @@ INTEGER*4                                        :: ibroncat                   !
 INTEGER*4                                        :: ierr                       ! error value
 LOGICAL*4                                        :: end_of_file                ! end of file has been reached
 INTEGER*4                                        :: brn_version                ! version of emission file
-REAL*4                                           :: qob                        ! emission strength read from emission record [g/s] 
-REAL*4                                           :: qww                        ! heat content read from emission record [MW] 
-REAL*4                                           :: hbron                      ! emission height read from emission record [m] 
-REAL*4                                           :: diameter                   ! diameter area source read from emission record (NOT stack diameter) [m] 
-REAL*4                                           :: szopp                      ! deviation emission height for area source = initial sigma_z [m] 
-REAL*4                                           :: x                          ! x coordinate of source location (RDM [m])                 
-REAL*4                                           :: y                          ! y coordinate of source location (RDM [m])
+real                                             :: qob                        ! emission strength read from emission record [g/s]
+real                                             :: qww                        ! heat content read from emission record [MW]
+real                                             :: hbron                      ! emission height read from emission record [m]
+real                                             :: diameter                   ! diameter area source read from emission record (NOT stack diameter) [m]
+real                                             :: szopp                      ! deviation emission height for area source = initial sigma_z [m]
+real                                             :: x                          ! x coordinate of source location (RDM [m])
+real                                             :: y                          ! y coordinate of source location (RDM [m])
 LOGICAL                                          :: country_selected           ! emission country has been selected
 LOGICAL                                          :: category_selected          ! emission category has been selected
 LOGICAL                                          :: VsDs_opt                   ! read stack parameters Ds/Vs/Ts from source file

--- a/ops_reken.f90
+++ b/ops_reken.f90
@@ -82,60 +82,60 @@ INTEGER*4, INTENT(IN)                            :: intpol                     !
                                                                                ! 0 interpolate between all meteo regions at specified location
                                                                                ! 1 use meteo parameters from user specified meteo region
                                                                                ! 2? use meteo parameters from user specified meteo file
-REAL*4,    INTENT(IN)                            :: vchemc                     ! chemical conversion rate, independent of light [%/h]
+real,      INTENT(IN)                            :: vchemc                     ! chemical conversion rate, independent of light [%/h]
 INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)                                                                                                                                           
-REAL*4,    INTENT(IN)                            :: vchemv                     ! chemical conversion rate, dependent on light [%/h]
+real,      INTENT(IN)                            :: vchemv                     ! chemical conversion rate, dependent on light [%/h]
 INTEGER*4, INTENT(IN)                            :: dv                         ! maximum code diurnal emission variation dverl
-REAL*4,    INTENT(IN)                            :: amol1                      ! molar mass primary component [g/mol]
-REAL*4,    INTENT(IN)                            :: amol2                      ! molar mass secondary component [g/mol]
-REAL*4,    INTENT(IN)                            :: amol21                     ! (molar mass secondary component)/(molar mass primary component) [-] 
-REAL*4,    INTENT(IN)                            :: ar                         ! proportionality constant in relation [OH] = ar Qr, with Qr = global radiation in W/m2 [(cm3 m2)/(molec W2)], see Egmond en Kesseboom (1983)
-REAL*4,    INTENT(IN)                            :: rno2nox                    ! season dependent component of [NO2]/[NOx] ratio [-]
-REAL*4,    INTENT(IN)                            :: ecvl(NSTAB, NTRAJ, *)      ! average diurnal emission variation for each stability/distance class
+real,      INTENT(IN)                            :: amol1                      ! molar mass primary component [g/mol]
+real,      INTENT(IN)                            :: amol2                      ! molar mass secondary component [g/mol]
+real,      INTENT(IN)                            :: amol21                     ! (molar mass secondary component)/(molar mass primary component) [-]
+real,      INTENT(IN)                            :: ar                         ! proportionality constant in relation [OH] = ar Qr, with Qr = global radiation in W/m2 [(cm3 m2)/(molec W2)], see Egmond en Kesseboom (1983)
+real,      INTENT(IN)                            :: rno2nox                    ! season dependent component of [NO2]/[NOx] ratio [-]
+real,      INTENT(IN)                            :: ecvl(NSTAB, NTRAJ, *)      ! average diurnal emission variation for each stability/distance class
 INTEGER*4, INTENT(IN)                            :: iseiz                      ! season index (0=long term; 1=year; 2=winter; 3=summer; 4=month in winter; 5=month in summer)
-REAL*4,    INTENT(IN)                            :: zf                         ! interpolation factor between summer and winter (zf << "zomer fractie" = summer fraction)
-REAL*4,    INTENT(IN)                            :: trafst(NTRAJ)              ! travel distances for each distance class [m]
+real,      INTENT(IN)                            :: zf                         ! interpolation factor between summer and winter (zf << "zomer fractie" = summer fraction)
+real,      INTENT(IN)                            :: trafst(NTRAJ)              ! travel distances for each distance class [m]
 INTEGER*4, INTENT(IN)                            :: knatdeppar                 ! choice for parameterisation wet deposition
                                                                                ! knatdeppar = 1: read wdeppar = scavenging coefficient [%/h]
                                                                                ! knatdeppar = 2: read wdeppar =  scavenging ratio, i.e. average ratio if rainwater concentrations and air concentration [-]
                                                                                ! knatdeppar = 3: if secondary components are present [SO2, NO2, NH3]. Wash-out and rain-out parameters are fixed in the OPS code (ops_init) [-]
 INTEGER*4, INTENT(IN)                            :: mb                         ! start month of meteo statistics period ("b" << begin = start) 
-REAL*4,    INTENT(IN)                            :: ugmoldep                   ! conversion factor from ug/m2/h to each of the deposition units in DEPUNITS 
-REAL*4,    INTENT(IN)                            :: dg                         ! diffusion coefficient in air [cm^2/s] 
+real,      INTENT(IN)                            :: ugmoldep                   ! conversion factor from ug/m2/h to each of the deposition units in DEPUNITS
+real,      INTENT(IN)                            :: dg                         ! diffusion coefficient in air [cm^2/s]
 LOGICAL,   INTENT(IN)                            :: irev                       ! TRUE for reversible wash-out 
-REAL*4,    INTENT(IN)                            :: scavcoef                   ! scavenging rate [%/h] 
-REAL*4,    INTENT(IN)                            :: koh                        ! second order reaction rate constant of reaction NO2 + OH -> HNO3 [cm3/(molec s)]
-REAL*4,    INTENT(IN)                            :: croutpri                   ! (wash-out + rain-out) ratio primary component, default value without correction for background concentration, season, stability class [-]
+real,      INTENT(IN)                            :: scavcoef                   ! scavenging rate [%/h]
+real,      INTENT(IN)                            :: koh                        ! second order reaction rate constant of reaction NO2 + OH -> HNO3 [cm3/(molec s)]
+real,      INTENT(IN)                            :: croutpri                   ! (wash-out + rain-out) ratio primary component, default value without correction for background concentration, season, stability class [-]
                                                                                ! icm = 1 (SO2): croutpri = wash out ratio at an N/S ratio of 1
                                                                                ! icm = 2 (NOx): croutpri = wash out ratio at an NO2/NOx ratio of 1
                                                                                ! icm = 3 (NH3): croutpri = wash out ratio (no correction)
-REAL*4,    INTENT(IN)                            :: rcno                       ! surface resistance Rc for NO [s/m]
-REAL*4,    INTENT(IN)                            :: rhno2                      ! ratio [HNO2]/[NOx] 
-REAL*4,    INTENT(IN)                            :: rchno3                     ! surface resistance Rc for HNO3 [s/m] 
+real,      INTENT(IN)                            :: rcno                       ! surface resistance Rc for NO [s/m]
+real,      INTENT(IN)                            :: rhno2                      ! ratio [HNO2]/[NOx]
+real,      INTENT(IN)                            :: rchno3                     ! surface resistance Rc for HNO3 [s/m]
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptor points  
 INTEGER*4, INTENT(IN)                            :: ircp                       ! index of receptorpoint
-REAL*4,    INTENT(IN)                            :: gxm                        ! x-coordinate of receptors (lon-lat) [degrees]
-REAL*4,    INTENT(IN)                            :: gym                        ! y-coordinate of receptors (lon-lat) [degrees]
-REAL*4,    INTENT(IN)                            :: xm                         ! x-coordinate of receptor points (RDM)
-REAL*4,    INTENT(IN)                            :: ym                         ! y-coordinate of receptor points (RDM)
-REAL*4,    INTENT(IN)                            :: zm                         ! z-coordinate of receptor points (RDM)
-REAL*4,    INTENT(IN)                            :: frac                       ! fraction of grid cell inside NL 
-REAL*4,    INTENT(IN)                            :: nh3bg_rcp                  ! NH3 background concentration (used in DEPAC) [ug/m3]  
-REAL*4,    INTENT(IN)                            :: so2bg_rcp                  ! SO2 background concentration (used in DEPAC) [ug/m3]  																																	   
-REAL*4,    INTENT(IN)                            :: rhno3_rcp                  ! ratio [HNO3]/[NO3]_total at receptor points, [NO3]_total = [HNO3] + [NO3_aerosol] 
-REAL*4,    INTENT(IN)                            :: bqrv                       ! source strength of space heating source (rv << "ruimteverwarming" = space heating) [g/s]
-REAL*4,    INTENT(IN)                            :: bqtr                       ! source strength of traffic source [g/s]
+real,      INTENT(IN)                            :: gxm                        ! x-coordinate of receptors (lon-lat) [degrees]
+real,      INTENT(IN)                            :: gym                        ! y-coordinate of receptors (lon-lat) [degrees]
+real,      INTENT(IN)                            :: xm                         ! x-coordinate of receptor points (RDM)
+real,      INTENT(IN)                            :: ym                         ! y-coordinate of receptor points (RDM)
+real,      INTENT(IN)                            :: zm                         ! z-coordinate of receptor points (RDM)
+real,      INTENT(IN)                            :: frac                       ! fraction of grid cell inside NL
+real,      INTENT(IN)                            :: nh3bg_rcp                  ! NH3 background concentration (used in DEPAC) [ug/m3]
+real,      INTENT(IN)                            :: so2bg_rcp                  ! SO2 background concentration (used in DEPAC) [ug/m3]
+real,      INTENT(IN)                            :: rhno3_rcp                  ! ratio [HNO3]/[NO3]_total at receptor points, [NO3]_total = [HNO3] + [NO3_aerosol]
+real,      INTENT(IN)                            :: bqrv                       ! source strength of space heating source (rv << "ruimteverwarming" = space heating) [g/s]
+real,      INTENT(IN)                            :: bqtr                       ! source strength of traffic source [g/s]
 INTEGER*4, INTENT(IN)                            :: bx                         ! x-coordinate of source 
 INTEGER*4, INTENT(IN)                            :: by                         ! y-coordinate of source 
-REAL*4,    INTENT(IN)                            :: bdiam                      ! source diameter [m]; if bdiam < 0 -> circular source, bdiam > 0 -> square sourc 
-REAL*4,    INTENT(IN)                            :: bsterkte                   ! source strength [g/s] 
-REAL*4,    INTENT(IN)                            :: bwarmte                    ! heat content of source [MW] 
-REAL*4,    INTENT(IN)                            :: bhoogte                    ! source height [m] 
-REAL*4,    INTENT(IN)                            :: bsigmaz                    ! spread in source height to represent different sources in a area source; 
+real,      INTENT(IN)                            :: bdiam                      ! source diameter [m]; if bdiam < 0 -> circular source, bdiam > 0 -> square sourc
+real,      INTENT(IN)                            :: bsterkte                   ! source strength [g/s]
+real,      INTENT(IN)                            :: bwarmte                    ! heat content of source [MW]
+real,      INTENT(IN)                            :: bhoogte                    ! source height [m]
+real,      INTENT(IN)                            :: bsigmaz                    ! spread in source height to represent different sources in a area source;
                                                                                ! also used for initial sigma_z (vertical dispersion) of emission (e.g. traffic, building influence) [m] 
-REAL*4,    INTENT(IN)                            :: bD_stack                   ! diameter of the stack [m]
-REAL*4,    INTENT(IN)                            :: bV_stack                   ! exit velocity of plume at stack tip [m/s]
-REAL*4,    INTENT(IN)                            :: bTs_stack                  ! temperature of effluent from stack [K]            
+real,      INTENT(IN)                            :: bD_stack                   ! diameter of the stack [m]
+real,      INTENT(IN)                            :: bV_stack                   ! exit velocity of plume at stack tip [m/s]
+real,      INTENT(IN)                            :: bTs_stack                  ! temperature of effluent from stack [K]
 LOGICAL,   INTENT(IN)                            :: bemis_horizontal           ! horizontal outflow of emission
 type(Tbuilding), INTENT(IN)                      :: bbuilding                  ! structure with building parameters
 type(TbuildingEffect), INTENT(IN)                :: buildingEffect             ! structure containing building effect tables
@@ -143,49 +143,49 @@ INTEGER*4, INTENT(IN)                            :: btgedr                     !
 INTEGER*4, INTENT(IN)                            :: bdegr                      ! option for particle size distribution
                                                                                ! bdegr >= 0 -> standard particle size distribution pmd
                                                                                ! bdegr  < 0 -> user-defined particle size distribution uspmd 
-REAL*4,    INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
-REAL*4,    INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
-REAL*4,    INTENT(IN)                            :: lu_tra_per(NLU)            ! landuse (percentages) for all classes over trajectory
-REAL*4,    INTENT(IN)                            :: lu_rcp_per(NLU)            ! landuse (percentages) for all classes for receptor
-REAL*4,    INTENT(IN)                            :: so2sek(NSEK)               ! coefficient in correction factor for SO2 background concentration for each wind direction sector; derived from 24 regional LML stations over 2003
-REAL*4,    INTENT(IN)                            :: no2sek(NSEK)               ! coefficient in correction factor for NO2 background concentration for each wind direction sector; derived from 15 regional LML stations over 2004
-REAL*4,    INTENT(IN)                            :: so2bgtra                   ! SO2 background concentration, trajectory averaged [ppb]
-REAL*4,    INTENT(IN)                            :: no2bgtra                   ! NO2 background concentration, trajectory averaged [ppb]
-REAL*4,    INTENT(IN)                            :: nh3bgtra                   ! NH3 background concentration, trajectory averaged [ppb]
+real,      INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
+real,      INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
+real,      INTENT(IN)                            :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
+real,      INTENT(IN)                            :: lu_tra_per(NLU)            ! landuse (percentages) for all classes over trajectory
+real,      INTENT(IN)                            :: lu_rcp_per(NLU)            ! landuse (percentages) for all classes for receptor
+real,      INTENT(IN)                            :: so2sek(NSEK)               ! coefficient in correction factor for SO2 background concentration for each wind direction sector; derived from 24 regional LML stations over 2003
+real,      INTENT(IN)                            :: no2sek(NSEK)               ! coefficient in correction factor for NO2 background concentration for each wind direction sector; derived from 15 regional LML stations over 2004
+real,      INTENT(IN)                            :: so2bgtra                   ! SO2 background concentration, trajectory averaged [ppb]
+real,      INTENT(IN)                            :: no2bgtra                   ! NO2 background concentration, trajectory averaged [ppb]
+real,      INTENT(IN)                            :: nh3bgtra                   ! NH3 background concentration, trajectory averaged [ppb]
 type(Tvchem), INTENT(INOUT)                      :: vchem2                     !                                                                                  
 INTEGER*4, INTENT(IN)                            :: maxidx                     ! max. number of particle classes (= 1 for gas)
-REAL*4,    INTENT(IN)                            :: pmd(NPARTCLASS,MAXDISTR)   ! standard particle size distributions 
-REAL*4,    INTENT(IN)                            :: uspmd(NPARTCLASS,MAXDISTR) ! user-defined particle size distributions 
+real,      INTENT(IN)                            :: pmd(NPARTCLASS,MAXDISTR)   ! standard particle size distributions
+real,      INTENT(IN)                            :: uspmd(NPARTCLASS,MAXDISTR) ! user-defined particle size distributions
 INTEGER*4, INTENT(IN)                            :: spgrid                     ! indicator for type of receptor points 
                                                                                ! spgrid = 0: regular grid of receptors, NL
                                                                                ! spgrid = 1: rectangular regular grid of receptors, user defined 
                                                                                ! spgrid = 2: receptors at specific locations, read from file
                                                                                ! spgrid = 3: receptors at user specific regular grid, not necessarily rectangular
-REAL*4,    INTENT(IN)                            :: grid                       ! grid resolution [m] 
+real,      INTENT(IN)                            :: grid                       ! grid resolution [m]
 LOGICAL,   INTENT(IN)                            :: subbron                    ! whether to create "subbrons" (sub-sources inside a area source) and "subareas" (sub receptors inside a grid cell) or not  
-REAL*4,    INTENT(IN)                            :: uurtot                     ! total number of hours in meteo statistics period ("uur"= hour) [hours]
-REAL*4,    INTENT(IN)                            :: routsec                    ! in-cloud (rain-out) scavenging ratio for secondary component
+real,      INTENT(IN)                            :: uurtot                     ! total number of hours in meteo statistics period ("uur"= hour) [hours]
+real,      INTENT(IN)                            :: routsec                    ! in-cloud (rain-out) scavenging ratio for secondary component
 
 ! SUBROUTINE ARGUMENTS - I/O       (INOUT)
-REAL*4,    INTENT(INOUT)                         :: rc                         ! surface resistance Rc [s/m] 
-REAL*8,    INTENT(INOUT)                         :: somvnsec(NPARTCLASS)       ! summed wet deposition flux secondary component [ug/m2/h] 
-REAL*8,    INTENT(INOUT)                         :: telvnsec(NPARTCLASS)       ! summed deposited mass per area for wet deposition of secondary component [ug/m2]
-REAL*8,    INTENT(INOUT)                         :: vvchem(NPARTCLASS)         ! summed chemical conversion rate [%/h] 
-REAL*8,    INTENT(INOUT)                         :: vtel(NPARTCLASS)           ! weighing factors for averaging vvchem (i.e. deposited mass)
-REAL*8,    INTENT(INOUT)                         :: somvnpri(NPARTCLASS)       ! summed wet deposition flux primary component [ug/m2/h] 
-REAL*8,    INTENT(INOUT)                         :: telvnpri(NPARTCLASS)       ! summed deposited mass per area for wet deposition of primary component [ug/m2]
+real,      INTENT(INOUT)                         :: rc                         ! surface resistance Rc [s/m]
+double precision,    INTENT(INOUT)               :: somvnsec(NPARTCLASS)       ! summed wet deposition flux secondary component [ug/m2/h]
+double precision,    INTENT(INOUT)               :: telvnsec(NPARTCLASS)       ! summed deposited mass per area for wet deposition of secondary component [ug/m2]
+double precision,    INTENT(INOUT)               :: vvchem(NPARTCLASS)         ! summed chemical conversion rate [%/h]
+double precision,    INTENT(INOUT)               :: vtel(NPARTCLASS)           ! weighing factors for averaging vvchem (i.e. deposited mass)
+double precision,    INTENT(INOUT)               :: somvnpri(NPARTCLASS)       ! summed wet deposition flux primary component [ug/m2/h]
+double precision,    INTENT(INOUT)               :: telvnpri(NPARTCLASS)       ! summed deposited mass per area for wet deposition of primary component [ug/m2]
 DOUBLE PRECISION,    INTENT(INOUT)               :: ddepri(nrrcp,NPARTCLASS)   ! dry deposition of primary component at receptor points [mol/ha/y] 
-REAL*8,    INTENT(INOUT)                         :: sdrypri(NPARTCLASS)        ! summed dry deposition of primary component [ug/m2/h]
-REAL*8,    INTENT(INOUT)                         :: snatpri(NPARTCLASS)        ! summed wet deposition of primary component [ug/m2/h]  (<< "nat" = wet)
-REAL*8,    INTENT(INOUT)                         :: sdrysec(NPARTCLASS)        ! summed dry deposition of secondary component [ug/m2/h]
-REAL*8,    INTENT(INOUT)                         :: snatsec(NPARTCLASS)        ! summed wet deposition of secondary component [ug/m2/h]  (<< "nat" = wet)
+double precision,    INTENT(INOUT)               :: sdrypri(NPARTCLASS)        ! summed dry deposition of primary component [ug/m2/h]
+double precision,    INTENT(INOUT)               :: snatpri(NPARTCLASS)        ! summed wet deposition of primary component [ug/m2/h]  (<< "nat" = wet)
+double precision,    INTENT(INOUT)               :: sdrysec(NPARTCLASS)        ! summed dry deposition of secondary component [ug/m2/h]
+double precision,    INTENT(INOUT)               :: snatsec(NPARTCLASS)        ! summed wet deposition of secondary component [ug/m2/h]  (<< "nat" = wet)
 DOUBLE PRECISION,    INTENT(INOUT)               :: cpri(nrrcp,NPARTCLASS)     ! concentration of primary component at receptor points [ug/m3] 
 DOUBLE PRECISION,    INTENT(INOUT)               :: csec(nrrcp,NPARTCLASS)     ! concentration of secondary component ar receptor points [ug/m3] 
 DOUBLE PRECISION,    INTENT(INOUT)               :: drydep(nrrcp,NPARTCLASS)   ! dry deposition at receptor points [mol/ha/y] 
 DOUBLE PRECISION,    INTENT(INOUT)               :: wetdep(nrrcp,NPARTCLASS)   ! wet deposition at receptor points ["depeh"] 
-REAL*4,    INTENT(INOUT)                         :: astat(NTRAJ,NCOMP,NSTAB,NSEK) ! meteo statistics for each distance class, stability/mixing height class, wind direction sector
+real,      INTENT(INOUT)                         :: astat(NTRAJ,NCOMP,NSTAB,NSEK) ! meteo statistics for each distance class, stability/mixing height class, wind direction sector
                                                                                !        1. number of hours for which a certain combination of classes has occurred [hours]
                                                                                !        2. maximal mixing height over transport distance [m]
                                                                                !        3. wind speed (at 10 m height) [m/s]
@@ -217,13 +217,13 @@ REAL*4,    INTENT(INOUT)                         :: astat(NTRAJ,NCOMP,NSTAB,NSEK
                                                                                !        25. surface resistance Rc of NO2 [s/m]
                                                                                !        26. surface resistance Rc of NH3 [s/m]
                                                                                !        27. surface resistance Rc of NO3 aerosol [s/m]
-REAL*4,    INTENT(INOUT)                         :: rno2_nox_sum(nrrcp)        ! NO2/NOx ratio, weighed sum over classes
+real,      INTENT(INOUT)                         :: rno2_nox_sum(nrrcp)        ! NO2/NOx ratio, weighed sum over classes
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record 
        
 ! SUBROUTINE ARGUMENTS - OUTPUT       (OUT)
-REAL*4,    INTENT(OUT)                           :: precip                     ! precipitation amount [mm]
-REAL*4,    INTENT(OUT)                           :: routpri                    ! in-cloud (rain-out) scavenging ratio for primary component [-]  
-REAL*4,    INTENT(OUT)                           :: dispg(NSTAB)               ! dispersion coefficients for vertical dispersion; sigma_z = dispg*x^disph [-]
+real,      INTENT(OUT)                           :: precip                     ! precipitation amount [mm]
+real,      INTENT(OUT)                           :: routpri                    ! in-cloud (rain-out) scavenging ratio for primary component [-]
+real,      INTENT(OUT)                           :: dispg(NSTAB)               ! dispersion coefficients for vertical dispersion; sigma_z = dispg*x^disph [-]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: istab                      ! teller over stabiliteitsklassen
@@ -244,132 +244,132 @@ INTEGER*4                                        :: kk                         !
 INTEGER*4                                        :: nb                         ! 
 INTEGER*4                                        :: karea                      ! 
 INTEGER*4                                        :: larea                      ! 
-REAL*4                                           :: aind                       ! voortgangsindicator
-REAL*4                                           :: htot                       ! 
-REAL*4                                           :: c                          ! 
-REAL*4                                           :: ueff                       ! wind speed at effective transport height heff; 
+real                                             :: aind                       ! voortgangsindicator
+real                                             :: htot
+real                                             :: c
+real                                             :: ueff                       ! wind speed at effective transport height heff;
                                                                                ! for short distances heff = plume height;
                                                                                ! for large distances heff = 1/2 mixing height;
                                                                                ! heff is interpolated for intermediate distances.
-REAL*4                                           :: rations                    ! trajectory verhouding N/S
-REAL*4                                           :: qbron                      ! 
-REAL*4                                           :: qtr                        ! 
-REAL*4                                           :: qruim                      ! 
-REAL*4                                           :: grad                       ! 
-REAL*4                                           :: qob                        ! 
-REAL*4                                           :: qww                        ! 
-REAL*4                                           :: hbron                      ! 
-REAL*4                                           :: percvk                     ! 
-REAL*4                                           :: grof                       ! 
-REAL*4                                           :: cgt                        ! 
-REAL*4                                           :: cgt_z                      ! hoogte afhankelijkelijke cgt
-REAL*4                                           :: x                          ! 
-REAL*4                                           :: y                          ! 
-REAL*4                                           :: diam                       ! 
-REAL*4                                           :: diameter                   ! 
-REAL*4                                           :: szopp                      ! 
-REAL*4                                           :: D_stack                    ! diameter of the stack [m]
-REAL*4                                           :: V_stack                    ! exit velocity of plume at stack tip [m/s]
-REAL*4                                           :: Ts_stack                   ! temperature of effluent from stack [K]
+real                                             :: rations                    ! trajectory verhouding N/S
+real                                             :: qbron
+real                                             :: qtr
+real                                             :: qruim
+real                                             :: grad
+real                                             :: qob
+real                                             :: qww
+real                                             :: hbron
+real                                             :: percvk
+real                                             :: grof
+real                                             :: cgt
+real                                             :: cgt_z                      ! hoogte afhankelijkelijke cgt
+real                                             :: x
+real                                             :: y
+real                                             :: diam
+real                                             :: diameter
+real                                             :: szopp
+real                                             :: D_stack                    ! diameter of the stack [m]
+real                                             :: V_stack                    ! exit velocity of plume at stack tip [m/s]
+real                                             :: Ts_stack                   ! temperature of effluent from stack [K]
 LOGICAL                                          :: emis_horizontal            ! horizontal outflow of emission  
 type(Tbuilding)                                  :: building                   ! structure with building paramaters
-REAL*4                                           :: buildingFact               ! The interpolated building effect from the buildingTable
-REAL*4                                           :: qrv                        ! 
-REAL*4                                           :: virty                      ! 
-REAL*4                                           :: consec                     ! 
-REAL*4                                           :: angle_SR_xaxis             ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
-REAL*4                                           :: disx                       ! linear distance between source and receptor [m]
-REAL*4                                           :: disxx                      ! effective travel distance between source and receptor [m]
-REAL*4                                           :: radius                     ! 
-REAL*4                                           :: uster_metreg_rcp           ! 
-REAL*4                                           :: temp_C                     ! temperature at height zmet_T [C]
-REAL*4                                           :: shear                      ! 
-REAL*4                                           :: ol_metreg_rcp              ! 
-REAL*4                                           :: h0                         ! 
-REAL*4                                           :: hum                        ! 
-REAL*4                                           :: rcno2d                     ! 
-REAL*4                                           :: rcnh3d                     ! 
-REAL*4                                           :: rcaerd                     ! 
-REAL*4                                           :: vw10                       ! 
-REAL*4                                           :: pcoef                      ! 
-REAL*4                                           :: htt                        ! 
-REAL*4                                           :: aant                       ! 
-REAL*4                                           :: xl                         ! 
-REAL*4                                           :: rb                         ! 
-REAL*4                                           :: rbm                        ! 
-REAL*4                                           :: ra4                        ! 
-REAL*4                                           :: ra4m                       ! 
-REAL*4                                           :: ra50                       ! 
-REAL*4                                           :: ra50m                      ! 
-REAL*4                                           :: xvglbr                     ! 
-REAL*4                                           :: xvghbr                     ! 
-REAL*4                                           :: xloc                       ! 
-REAL*4                                           :: xl100                      ! 
-REAL*4                                           :: rad                        ! 
-REAL*4                                           :: rcso2                      ! 
-REAL*4                                           :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2] 
-REAL*4                                           :: regenk                     ! 
-REAL*4                                           :: buil                       ! 
-REAL*4                                           :: rint                       ! 
-REAL*4                                           :: aksek(NSEK)                ! .... (dummy output van ops_statparexp)
-REAL*4                                           :: uster_rcp                  ! friction velocity at receptor; for z0 at receptor [m/s]
-REAL*4                                           :: ol_rcp                     ! Monin-Obukhov length at receptor; for z0 at receptor [m/s] 
-REAL*4                                           :: uster_src                  ! 
-REAL*4                                           :: ol_src                     ! 
-REAL*4                                           :: uster_tra                  ! 
-REAL*4                                           :: ol_tra                     ! 
-REAL*4                                           :: uh                         ! 
-REAL*4                                           :: zu                         ! 
-REAL*4                                           :: onder                      ! 
-REAL*4                                           :: xlm                        ! 
-REAL*4                                           :: onderm                     ! 
-REAL*4                                           :: qbpri                      ! 
-REAL*4                                           :: qsec                       ! 
-REAL*4                                           :: sigz                       ! 
-REAL*4                                           :: ccc                        ! undepleted concentration including part above mixing layer; 
+real                                             :: buildingFact               ! The interpolated building effect from the buildingTable
+real                                             :: qrv
+real                                             :: virty
+real                                             :: consec
+real                                             :: angle_SR_xaxis             ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
+real                                             :: disx                       ! linear distance between source and receptor [m]
+real                                             :: disxx                      ! effective travel distance between source and receptor [m]
+real                                             :: radius
+real                                             :: uster_metreg_rcp
+real                                             :: temp_C                     ! temperature at height zmet_T [C]
+real                                             :: shear
+real                                             :: ol_metreg_rcp
+real                                             :: h0
+real                                             :: hum
+real                                             :: rcno2d
+real                                             :: rcnh3d
+real                                             :: rcaerd
+real                                             :: vw10
+real                                             :: pcoef
+real                                             :: htt
+real                                             :: aant
+real                                             :: xl
+real                                             :: rb
+real                                             :: rbm
+real                                             :: ra4
+real                                             :: ra4m
+real                                             :: ra50
+real                                             :: ra50m
+real                                             :: xvglbr
+real                                             :: xvghbr
+real                                             :: xloc
+real                                             :: xl100
+real                                             :: rad
+real                                             :: rcso2
+real                                             :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2]
+real                                             :: regenk
+real                                             :: buil
+real                                             :: rint
+real                                             :: aksek(NSEK)                ! .... (dummy output van ops_statparexp)
+real                                             :: uster_rcp                  ! friction velocity at receptor; for z0 at receptor [m/s]
+real                                             :: ol_rcp                     ! Monin-Obukhov length at receptor; for z0 at receptor [m/s]
+real                                             :: uster_src
+real                                             :: ol_src
+real                                             :: uster_tra
+real                                             :: ol_tra
+real                                             :: uh
+real                                             :: zu
+real                                             :: onder
+real                                             :: xlm
+real                                             :: onderm
+real                                             :: qbpri
+real                                             :: qsec
+real                                             :: sigz
+real                                             :: ccc                        ! undepleted concentration including part above mixing layer;
                                                                                ! is needed for e.g. wet deposition.
-REAL*4                                           :: rcsec                      ! 
-REAL*4                                           :: rc_sec_rcp                 ! 
-REAL*4                                           :: rb_rcp                     ! 
-REAL*4                                           :: ra50_rcp                   ! 
-REAL*4                                           :: raz_rcp                    ! 
-REAL*4                                           :: rc_rcp                     ! 
-REAL*4                                           :: ra4_rcp                    ! 
-REAL*4                                           :: vg50_rcp                   ! 
-REAL*4                                           :: pr                         ! 
-REAL*4                                           :: utr                        ! average wind speed over the trajectory (m/s)
-REAL*4                                           :: vchem                      ! 
-REAL*4                                           :: vg50trans                  ! 
-REAL*4                                           :: vgpart                     ! 
-REAL*4                                           :: rkc                        ! 
-REAL*4                                           :: ri                         ! 
-REAL*4                                           :: twt                        ! 
-REAL*4                                           :: vnatpri                    ! 
-REAL*4                                           :: cq2                        ! 
-REAL*4                                           :: cdn                        ! 
-REAL*4                                           :: cch                        ! 
-REAL*4                                           :: cratio                     ! 
-REAL*4                                           :: rhno3                      ! 
-REAL*4                                           :: rrno2nox                   ! 
-REAL*4                                           :: vchemnh3                   ! 
-REAL*4                                           :: dx                         ! 
-REAL*4                                           :: dy                         ! 
-REAL*4                                           :: dxsub                      ! 
-REAL*4                                           :: dysub                      ! 
-REAL*4                                           :: gbx                        ! 
-REAL*4                                           :: gby                        ! 
-REAL*4                                           :: rctra_0
-REAL*4                                           :: rctra_50
-REAL*4                                           :: rclocal
-REAL*4                                           :: rcsrc
-REAL*4                                           :: ra4src
-REAL*4                                           :: rb_src
-REAL*4                                           :: ra50src
-REAL*4                                           :: ra4tra
-REAL*4                                           :: ra50tra
-REAL*4                                           :: rb_tra
-REAL*4                                           :: rnox                       ! NO2/NOx ratio
-REAL*4                                           :: xg
+real                                             :: rcsec
+real                                             :: rc_sec_rcp
+real                                             :: rb_rcp
+real                                             :: ra50_rcp
+real                                             :: raz_rcp
+real                                             :: rc_rcp
+real                                             :: ra4_rcp
+real                                             :: vg50_rcp
+real                                             :: pr
+real                                             :: utr                        ! average wind speed over the trajectory (m/s)
+real                                             :: vchem
+real                                             :: vg50trans
+real                                             :: vgpart
+real                                             :: rkc
+real                                             :: ri
+real                                             :: twt
+real                                             :: vnatpri
+real                                             :: cq2
+real                                             :: cdn
+real                                             :: cch
+real                                             :: cratio
+real                                             :: rhno3
+real                                             :: rrno2nox
+real                                             :: vchemnh3
+real                                             :: dx
+real                                             :: dy
+real                                             :: dxsub
+real                                             :: dysub
+real                                             :: gbx
+real                                             :: gby
+real                                             :: rctra_0
+real                                             :: rctra_50
+real                                             :: rclocal
+real                                             :: rcsrc
+real                                             :: ra4src
+real                                             :: rb_src
+real                                             :: ra50src
+real                                             :: ra4tra
+real                                             :: ra50tra
+real                                             :: rb_tra
+real                                             :: rnox                       ! NO2/NOx ratio
+real                                             :: xg
 
 LOGICAL                                          :: inc_rcp                    ! increase receptorpoints
 LOGICAL                                          :: z0found                    ! Wel of geen z0 gevonden
@@ -747,25 +747,25 @@ PARAMETER      (ROUTINENAAM = 'wind_rek')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: bx                         ! 
 INTEGER*4, INTENT(IN)                            :: by                         ! 
-REAL*4,    INTENT(IN)                            :: bdiam                      ! 
-REAL*4,    INTENT(IN)                            :: bsterkte                   ! 
-REAL*4,    INTENT(IN)                            :: bwarmte                    ! 
-REAL*4,    INTENT(IN)                            :: bhoogte                    ! 
-REAL*4,    INTENT(IN)                            :: bsigmaz                    ! 
-REAL*4,    INTENT(IN)                            :: bD_stack                   ! diameter of the stack [m]
-REAL*4,    INTENT(IN)                            :: bV_stack                   ! exit velocity of plume at stack tip [m/s]
-REAL*4,    INTENT(IN)                            :: bTs_stack                  ! temperature of effluent from stack [K]            
+real,      INTENT(IN)                            :: bdiam
+real,      INTENT(IN)                            :: bsterkte
+real,      INTENT(IN)                            :: bwarmte
+real,      INTENT(IN)                            :: bhoogte
+real,      INTENT(IN)                            :: bsigmaz
+real,      INTENT(IN)                            :: bD_stack                   ! diameter of the stack [m]
+real,      INTENT(IN)                            :: bV_stack                   ! exit velocity of plume at stack tip [m/s]
+real,      INTENT(IN)                            :: bTs_stack                  ! temperature of effluent from stack [K]
 LOGICAL,   INTENT(IN)                            :: bemis_horizontal           ! horizontal outflow of emission
 type(Tbuilding), INTENT(IN)                      :: bbuilding                  ! structure with building parameters
 INTEGER*4, INTENT(IN)                            :: btgedr                     ! 
 INTEGER*4, INTENT(IN)                            :: bdegr                      ! 
-REAL*4,    INTENT(IN)                            :: bqrv                       ! 
-REAL*4,    INTENT(IN)                            :: bqtr                       ! 
-REAL*4,    INTENT(IN)                            :: gxm                        ! 
-REAL*4,    INTENT(IN)                            :: gym                        ! 
-REAL*4,    INTENT(IN)                            :: xm                         ! 
-REAL*4,    INTENT(IN)                            :: ym                         ! 
-REAL*4,    INTENT(IN)                            :: grid                       ! 
+real,      INTENT(IN)                            :: bqrv
+real,      INTENT(IN)                            :: bqtr
+real,      INTENT(IN)                            :: gxm
+real,      INTENT(IN)                            :: gym
+real,      INTENT(IN)                            :: xm
+real,      INTENT(IN)                            :: ym
+real,      INTENT(IN)                            :: grid
 INTEGER*4, INTENT(IN)                            :: nk                         ! 
 INTEGER*4, INTENT(IN)                            :: nr                         ! 
 INTEGER*4, INTENT(IN)                            :: mrcp                       ! 
@@ -776,31 +776,31 @@ INTEGER*4, INTENT(IN)                            :: karea                      !
 INTEGER*4, INTENT(IN)                            :: larea                      ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: angle_SR_xaxis             ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
-REAL*4,    INTENT(OUT)                           :: disx                       ! linear distance between source and receptor [m] 
-REAL*4,    INTENT(OUT)                           :: x                          ! 
-REAL*4,    INTENT(OUT)                           :: y                          ! 
-REAL*4,    INTENT(OUT)                           :: qob                        ! 
-REAL*4,    INTENT(OUT)                           :: qww                        ! 
-REAL*4,    INTENT(OUT)                           :: hbron                      ! 
-REAL*4,    INTENT(OUT)                           :: szopp                      ! 
-REAL*4,    INTENT(OUT)                           :: D_stack                    ! diameter of the stack [m]
-REAL*4,    INTENT(OUT)                           :: V_stack                    ! exit velocity of plume at stack tip [m/s]
-REAL*4,    INTENT(OUT)                           :: Ts_stack                   ! temperature of effluent from stack [K]            
+real,      INTENT(OUT)                           :: angle_SR_xaxis             ! angle between source-receptor vector and x-axis (needed for building effect) [degrees]
+real,      INTENT(OUT)                           :: disx                       ! linear distance between source and receptor [m]
+real,      INTENT(OUT)                           :: x
+real,      INTENT(OUT)                           :: y
+real,      INTENT(OUT)                           :: qob
+real,      INTENT(OUT)                           :: qww
+real,      INTENT(OUT)                           :: hbron
+real,      INTENT(OUT)                           :: szopp
+real,      INTENT(OUT)                           :: D_stack                    ! diameter of the stack [m]
+real,      INTENT(OUT)                           :: V_stack                    ! exit velocity of plume at stack tip [m/s]
+real,      INTENT(OUT)                           :: Ts_stack                   ! temperature of effluent from stack [K]
 LOGICAL,   INTENT(OUT)                           :: emis_horizontal            ! horizontal outflow of emission
 type(Tbuilding), INTENT(OUT)                     :: building                   ! strucure with building parameters
 INTEGER*4, INTENT(OUT)                           :: ibtg                       ! 
 INTEGER*4, INTENT(OUT)                           :: idgr                       ! 
-REAL*4,    INTENT(OUT)                           :: qrv                        ! 
-REAL*4,    INTENT(OUT)                           :: qtr                        ! 
+real,      INTENT(OUT)                           :: qrv
+real,      INTENT(OUT)                           :: qtr
 INTEGER*4, INTENT(OUT)                           :: rond                       ! 
-REAL*4,    INTENT(OUT)                           :: diameter                   ! 
+real,      INTENT(OUT)                           :: diameter
 INTEGER*4, INTENT(OUT)                           :: iwd                        ! 
 INTEGER*4, INTENT(OUT)                           :: isek                       ! 
 
 ! LOCAL VARIABLES
-REAL*4                                           :: dx                         ! 
-REAL*4                                           :: dy                         ! 
+real                                             :: dx
+real                                             :: dy
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_resist_rek.f90
+++ b/ops_resist_rek.f90
@@ -58,97 +58,97 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_resist_rek')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: vchemc                     ! chemical conversion rate [%/h]
+real,      INTENT(IN)                            :: vchemc                     ! chemical conversion rate [%/h]
 INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)
-REAL*4,    INTENT(IN)                            :: vchemv                     ! 
-REAL*4,    INTENT(IN)                            :: rad                        ! 
+real,      INTENT(IN)                            :: vchemv
+real,      INTENT(IN)                            :: rad
 LOGICAL,   INTENT(IN)                            :: isec                       ! TRUE als component=[SO2, NOx, NH3]
 INTEGER*4, INTENT(IN)                            :: icm                        ! 
-REAL*4,    INTENT(IN)                            :: rcso2                      ! 
-REAL*4,    INTENT(IN)                            :: regenk                     ! 
-REAL*4,    INTENT(IN)                            :: rcaerd                     ! surface resistance NO3_aerosol [s/m]
+real,      INTENT(IN)                            :: rcso2
+real,      INTENT(IN)                            :: regenk
+real,      INTENT(IN)                            :: rcaerd                     ! surface resistance NO3_aerosol [s/m]
 INTEGER*4, INTENT(IN)                            :: iseiz                      ! 
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
 INTEGER*4, INTENT(IN)                            :: itra                       ! 
-REAL*4,    INTENT(IN)                            :: ar                         ! 
-REAL*4,    INTENT(IN)                            :: rno2nox                    ! 
-REAL*4,    INTENT(IN)                            :: rcnh3d                     ! 
-REAL*4,    INTENT(IN)                            :: vchemnh3
+real,      INTENT(IN)                            :: ar
+real,      INTENT(IN)                            :: rno2nox
+real,      INTENT(IN)                            :: rcnh3d
+real,      INTENT(IN)                            :: vchemnh3
 type(Tvchem), INTENT(IN)                         :: vchem2                     ! 
-REAL*4,    INTENT(IN)                            :: hum                        ! 
-REAL*4,    INTENT(IN)                            :: uster_rcp                  ! friction velocity at receptor; for z0 at receptor [m/s]
-REAL*4,    INTENT(IN)                            :: ol_rcp                     ! Monin-Obukhov length at receptor; for z0 at receptor [m/s]
-REAL*4,    INTENT(IN)                            :: uster_tra                  ! 
-REAL*4,    INTENT(IN)                            :: ol_tra                     ! 
-REAL*4,    INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
-REAL*4,    INTENT(IN)                            :: rcno2d                     ! 
+real,      INTENT(IN)                            :: hum
+real,      INTENT(IN)                            :: uster_rcp                  ! friction velocity at receptor; for z0 at receptor [m/s]
+real,      INTENT(IN)                            :: ol_rcp                     ! Monin-Obukhov length at receptor; for z0 at receptor [m/s]
+real,      INTENT(IN)                            :: uster_tra
+real,      INTENT(IN)                            :: ol_tra
+real,      INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
+real,      INTENT(IN)                            :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
+real,      INTENT(IN)                            :: rcno2d
 INTEGER*4, INTENT(IN)                            :: kdeel                      ! 
 INTEGER*4, INTENT(IN)                            :: mb                         ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: temp_C                     ! temperature at height zmet_T [C]
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: zm                         ! 
-REAL*4,    INTENT(IN)                            :: koh                        ! 
-REAL*4,    INTENT(IN)                            :: rations                    ! 
-REAL*4,    INTENT(IN)                            :: rhno3                      ! 
-REAL*4,    INTENT(IN)                            :: rcno                       ! surface resistance for NO [s/m]
-REAL*4,    INTENT(IN)                            :: rhno2                      ! ration hno2/nox
-REAL*4,    INTENT(IN)                            :: rchno3                     ! HNO3
-REAL*4,    INTENT(IN)                            :: croutpri                   ! constant (initial) in-cloud scavenging ratio [-] for primary component                   
-REAL*4,    INTENT(IN)                            :: rrno2nox                   ! ruimtelijke variatie in no2/nox verhouding
-REAL*4,    INTENT(IN)                            :: rhno3_rcp                  ! 
-REAL*4,    INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: ol_src                     ! 
-REAL*4,    INTENT(IN)                            :: uster_src                  ! 
-REAL*4,    INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
-REAL*4,    INTENT(IN)                            :: nh3bg_rcp                  ! 
-REAL*4,    INTENT(IN)                            :: nh3bgtra                   ! 
-REAL*4,    INTENT(IN)                            :: so2bg_rcp                  ! 
-REAL*4,    INTENT(IN)                            :: so2bgtra                   ! 
-REAL*4,    INTENT(IN)                            :: gym                        !
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: temp_C                     ! temperature at height zmet_T [C]
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: zm
+real,      INTENT(IN)                            :: koh
+real,      INTENT(IN)                            :: rations
+real,      INTENT(IN)                            :: rhno3
+real,      INTENT(IN)                            :: rcno                       ! surface resistance for NO [s/m]
+real,      INTENT(IN)                            :: rhno2                      ! ration hno2/nox
+real,      INTENT(IN)                            :: rchno3                     ! HNO3
+real,      INTENT(IN)                            :: croutpri                   ! constant (initial) in-cloud scavenging ratio [-] for primary component
+real,      INTENT(IN)                            :: rrno2nox                   ! ruimtelijke variatie in no2/nox verhouding
+real,      INTENT(IN)                            :: rhno3_rcp
+real,      INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(IN)                            :: ol_src
+real,      INTENT(IN)                            :: uster_src
+real,      INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
+real,      INTENT(IN)                            :: nh3bg_rcp
+real,      INTENT(IN)                            :: nh3bgtra
+real,      INTENT(IN)                            :: so2bg_rcp
+real,      INTENT(IN)                            :: so2bgtra
+real,      INTENT(IN)                            :: gym
 LOGICAL,   INTENT(IN)                            :: gasv                       !
-REAL*4,    INTENT(IN)                            :: lu_rcp_per(NLU)            ! land use percentages for all land use classes of receptor
-REAL*4,    INTENT(IN)                            :: lu_tra_per(NLU)            ! land use percentages for all land use classes over trajectory
+real,      INTENT(IN)                            :: lu_rcp_per(NLU)            ! land use percentages for all land use classes of receptor
+real,      INTENT(IN)                            :: lu_tra_per(NLU)            ! land use percentages for all land use classes over trajectory
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: rb                         ! 
-REAL*4,    INTENT(INOUT)                         :: ra4                        ! 
-REAL*4,    INTENT(INOUT)                         :: ra50                       ! 
+real,      INTENT(INOUT)                         :: rb
+real,      INTENT(INOUT)                         :: ra4
+real,      INTENT(INOUT)                         :: ra50
 LOGICAL,   INTENT(INOUT)                         :: depudone                   !
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: routpri                    ! in-cloud scavenging ratio for primary component
+real,      INTENT(OUT)                           :: routpri                    ! in-cloud scavenging ratio for primary component
                                                                                ! (rout << rain-out = in-cloud) [-] 
-REAL*4,    INTENT(OUT)                           :: vchem                      ! chemical conversion rate [%/h]
-REAL*4,    INTENT(OUT)                           :: uh                         ! 
+real,      INTENT(OUT)                           :: vchem                      ! chemical conversion rate [%/h]
+real,      INTENT(OUT)                           :: uh
 
 ! Canopy resistances
 ! Note: for particles, Rc is defined in ops_depoparexp 
-REAL*4,    INTENT(OUT)                           :: rc                         ! 
-REAL*4,    INTENT(OUT)                           :: rcsec                      ! 
-REAL*4,    INTENT(OUT)                           :: rc_sec_rcp                 ! 
-REAL*4,    INTENT(OUT)                           :: rcsrc                      ! canopy resistance at the source, no re-emission allowed [s/m]; is used for the computation of 
+real,      INTENT(OUT)                           :: rc
+real,      INTENT(OUT)                           :: rcsec
+real,      INTENT(OUT)                           :: rc_sec_rcp
+real,      INTENT(OUT)                           :: rcsrc                      ! canopy resistance at the source, no re-emission allowed [s/m]; is used for the computation of
                                                                                ! cq1 = source depletion ratio for dry deposition for phase 1, area source  
-REAL*4,    INTENT(OUT)                           :: rctra_0                    ! canopy resistance representative for the trajectory, no re-emission allowed [s/m];
+real,      INTENT(OUT)                           :: rctra_0                    ! canopy resistance representative for the trajectory, no re-emission allowed [s/m];
                                                                                ! is used for source depletion (loss over trajectory)
-REAL*4,    INTENT(OUT)                           :: rc_rcp                     ! canopy resistance at receptor, no re-emission allowed [s/m];
+real,      INTENT(OUT)                           :: rc_rcp                     ! canopy resistance at receptor, no re-emission allowed [s/m];
                                                                                ! is used for deposition gradient at receptor
-REAL*4,    INTENT(OUT)                           :: rclocal                    ! canopy resistance at receptor, re-emission allowed [s/m];  
+real,      INTENT(OUT)                           :: rclocal                    ! canopy resistance at receptor, re-emission allowed [s/m];
                                                                                ! is used for the computation of drypri, the local depsosition at the receptor
-																			   
-REAL*4,    INTENT(OUT)                           :: rb_rcp                     ! 
-REAL*4,    INTENT(OUT)                           :: ra4_rcp                    ! 
-REAL*4,    INTENT(OUT)                           :: ra50_rcp                   ! 
-REAL*4,    INTENT(OUT)                           :: ra4src                     ! 
-REAL*4,    INTENT(OUT)                           :: rb_src                     ! 
-REAL*4,    INTENT(OUT)                           :: ra50src                    ! 
-REAL*4,    INTENT(OUT)                           :: ra4tra                     ! 
-REAL*4,    INTENT(OUT)                           :: ra50tra                    ! 
-REAL*4,    INTENT(OUT)                           :: rb_tra                     ! 
-REAL*4,    INTENT(OUT)                           :: raz_rcp                    !
-REAL*4,    INTENT(OUT)                           :: rnox                       ! NO2/NOx ratio
- 
+
+real,      INTENT(OUT)                           :: rb_rcp
+real,      INTENT(OUT)                           :: ra4_rcp
+real,      INTENT(OUT)                           :: ra50_rcp
+real,      INTENT(OUT)                           :: ra4src
+real,      INTENT(OUT)                           :: rb_src
+real,      INTENT(OUT)                           :: ra50src
+real,      INTENT(OUT)                           :: ra4tra
+real,      INTENT(OUT)                           :: ra50tra
+real,      INTENT(OUT)                           :: rb_tra
+real,      INTENT(OUT)                           :: raz_rcp
+real,      INTENT(OUT)                           :: rnox                       ! NO2/NOx ratio
+
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: day_of_year                ! 
@@ -159,40 +159,40 @@ INTEGER*4, DIMENSION(2)                          :: mnt_select                 !
 INTEGER*4                                        :: nwet                       ! 
 INTEGER*4                                        :: icnr                       ! 
 INTEGER*4                                        :: luclass                    ! 
-REAL*4                                           :: percn                      ! 
-REAL*4                                           :: chemn                      ! 
-REAL*4                                           :: scno2nox                   ! 
-REAL*4                                           :: chemr                      ! 
-REAL*4                                           :: rcno2                      ! 
-REAL*4                                           :: r                          ! 
-REAL*4                                           :: glrad                      ! 
-REAL*4                                           :: d                          ! 
-REAL*4                                           :: ratns                      ! 
-REAL*4                                           :: rcc                        ! 
-REAL*4                                           :: vdc                        ! 
-REAL*4                                           :: rcaer                      ! 
-REAL*4                                           :: vdaer                      ! 
-REAL*4                                           :: vg                         ! 
-REAL*4                                           :: rchno2                     ! 
-REAL*4                                           :: dh                         ! 
-REAL*4                                           :: fx                         ! weegfactor
-REAL*4                                           :: som_rc_rcp 
-REAL*4                                           :: som2_rc_rcp 
-REAL*4                                           :: som_rc_local 
-REAL*4                                           :: som2_rctra_0 
-REAL*4                                           :: som_rctra_0 
-REAL*4                                           :: som_rcsrc
-REAL*4                                           :: telmaand 
-REAL*4                                           :: catm 
-REAL*4                                           :: c_ave_prev_nh3
-REAL*4                                           :: c_ave_prev_so2
-REAL*4                                           :: cfact
-REAL*4                                           :: ccomp_tot
-REAL*4                                           :: rc_tot
-REAL*4                                           :: rc_sum
-REAL*4                                           :: sinphi
+real                                             :: percn
+real                                             :: chemn
+real                                             :: scno2nox
+real                                             :: chemr
+real                                             :: rcno2
+real                                             :: r
+real                                             :: glrad
+real                                             :: d
+real                                             :: ratns
+real                                             :: rcc
+real                                             :: vdc
+real                                             :: rcaer
+real                                             :: vdaer
+real                                             :: vg
+real                                             :: rchno2
+real                                             :: dh
+real                                             :: fx                         ! weegfactor
+real                                             :: som_rc_rcp
+real                                             :: som2_rc_rcp
+real                                             :: som_rc_local
+real                                             :: som2_rctra_0
+real                                             :: som_rctra_0
+real                                             :: som_rcsrc
+real                                             :: telmaand
+real                                             :: catm
+real                                             :: c_ave_prev_nh3
+real                                             :: c_ave_prev_so2
+real                                             :: cfact
+real                                             :: ccomp_tot
+real                                             :: rc_tot
+real                                             :: rc_sum
+real                                             :: sinphi
 INTEGER                                          :: i
-REAL*4, PARAMETER                                :: catm_min = 0.1E-05
+real,   PARAMETER                                :: catm_min = 0.1E-05
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -574,18 +574,18 @@ PARAMETER      (ROUTINENAAM = 'vdsecaer')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: icmp                       ! 
 INTEGER*4, INTENT(IN)                            :: nwet                       ! 
-REAL*4,    INTENT(IN)                            :: ust                        ! 
-REAL*4,    INTENT(IN)                            :: ol                         ! 
-REAL*4,    INTENT(IN)                            :: rh                         ! 
-REAL*4,    INTENT(IN)                            :: Uh                         ! 
-REAL*4,    INTENT(IN)                            :: ra                         ! 
-REAL*4,    INTENT(IN)                            :: znul                       ! 
+real,      INTENT(IN)                            :: ust
+real,      INTENT(IN)                            :: ol
+real,      INTENT(IN)                            :: rh
+real,      INTENT(IN)                            :: Uh
+real,      INTENT(IN)                            :: ra
+real,      INTENT(IN)                            :: znul
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: vd                         ! 
+real,      INTENT(OUT)                           :: vd
 
 ! LOCAL VARIABLES
-REAL*4                                           :: E                          ! 
+real                                             :: E
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_scalefac.f90
+++ b/ops_scalefac.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Compute scaling factors for printing of concentrations and depositions. A scaling factor is the ratio between the 
@@ -37,7 +40,7 @@
 ! CALLED FUNCTIONS   :
 ! UPDATE HISTORY     :
 !-------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ops_scalefac(nrrcp, cpri, csec, drydep, wetdep, scale_con, scale_sec, scale_dep, cseccor, scale_sec_cor)
+SUBROUTINE ops_scalefac(nrrcp, nsubsec, cpri, csec, drydep, wetdep, scale_con, scale_sec, scale_dep, csubsec, scale_subsec)
 
 USE m_commonconst                                                              ! EPS_DELTA only
 
@@ -49,23 +52,25 @@ PARAMETER        (ROUTINENAAM = 'ops_scalefac')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptor points
+INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number sub-secondary species
 REAL*4,    INTENT(IN)                            :: cpri(nrrcp)                ! array van primaire concentraties
 REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! array van secundaire concentraties
 REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! array van droge depositie
 REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! array van natte depositie
-REAL*4,    INTENT(IN), OPTIONAL                  :: cseccor(nrrcp)             ! concentration of second secondary substance
+REAL*4,    INTENT(IN), OPTIONAL                  :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary substance [ug/m3]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 REAL*4,    INTENT(OUT)                           :: scale_con                  ! schaal vergr. concentratie
 REAL*4,    INTENT(OUT)                           :: scale_sec                  ! schaal vergr. secundaire concentratie
 REAL*4,    INTENT(OUT)                           :: scale_dep                  ! schaal vergr. droge depositie
-REAL*4,    INTENT(OUT), OPTIONAL                 :: scale_sec_cor              ! schaal vergr. secundaire concentratie in gasvorm
+REAL*4,    INTENT(OUT), OPTIONAL                 :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: i                          ! teller over schaalfactoren
+INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
 REAL*4                                           :: cmax                       ! grootst voorkomende primaire concentratie
 REAL*4                                           :: csmax                      ! grootst voorkomende secundaire concentratie
-REAL*4                                           :: csgmax                     ! grootst voorkomende secundaire concentratie in gasvorm
+REAL*4                                           :: csubsecmax(nsubsec)        ! maximal value csubsec
 REAL*4                                           :: ddepmax                    ! grootst voorkomende droge depositie
 REAL*4                                           :: depntmax                   ! grootst voorkomende natte depositie
 REAL*4                                           :: s                          ! schaalfactor
@@ -73,7 +78,7 @@ REAL*4                                           :: tc                         !
 REAL*4                                           :: td                         ! teller aantal te grote droge dep.
 REAL*4                                           :: tn                         ! teller aantal te grote natte dep.
 REAL*4                                           :: ts                         ! teller aantal te grote sec. conc.
-REAL*4                                           :: tg                         ! teller aantal te grote sec. conc. gas
+REAL*4                                           :: tsubsec(nsubsec)                ! number of sub-secondary species with too large concentrations
 REAL*4                                           :: scale_dry                  ! schaal vergr. concentratie
 REAL*4                                           :: scale_wet                  ! schaal vergr. concentratie
 
@@ -86,7 +91,7 @@ sccsida = '%W%:%E%'//char(0)
 !
 cmax     = MAXVAL(cpri(:))
 csmax    = MAXVAL(csec(:))
-IF (PRESENT(cseccor)) csgmax = MAXVAL(cseccor(:))
+IF (PRESENT(csubsec)) csubsecmax = MAXVAL(csubsec,1)
 ddepmax  = MAXVAL(drydep(:))
 depntmax = MAXVAL(wetdep(:))
 
@@ -95,7 +100,7 @@ depntmax = MAXVAL(wetdep(:))
 !
 scale_con = 1.0e-10
 scale_sec = 1.0e-10
-IF (PRESENT(cseccor)) scale_sec_cor = 1.0e-10
+IF (PRESENT(csubsec)) scale_subsec = 1.0e-10
 scale_dry = 1.0e-10
 scale_wet = 1.0e-10
 ! 
@@ -110,10 +115,12 @@ DO i = -10, 30
   IF (csmax .GT. (0. + EPS_DELTA) .AND. (2000./csmax) .GT. (s + EPS_DELTA)) THEN
      scale_sec = s
   ENDIF
-  IF (PRESENT(cseccor)) THEN
-    IF (csgmax .GT. (0. + EPS_DELTA) .AND. (2000./csgmax) .GT. (s + EPS_DELTA)) THEN
-       scale_sec_cor = s
-    ENDIF
+  IF (PRESENT(csubsec)) THEN
+    do isubsec = 1,nsubsec
+       IF (csubsecmax(isubsec) .GT. (0. + EPS_DELTA) .AND. (2000./csubsecmax(isubsec)) .GT. (s + EPS_DELTA)) THEN
+          scale_subsec(isubsec) = s
+       ENDIF
+    enddo 
   ENDIF
   IF (ddepmax .GT. (0. + EPS_DELTA) .AND. (2000./ddepmax) .GT. (s + EPS_DELTA)) THEN
      scale_dry = s
@@ -127,7 +134,11 @@ ENDDO
 !
 tc = COUNT(cpri(:)*scale_con .GT. 999.+EPS_DELTA)
 ts = COUNT(csec(:)*scale_sec .GT. 999.+EPS_DELTA)
-IF (PRESENT(cseccor)) tg = COUNT(cseccor(:)*scale_sec_cor .GT. 999.+EPS_DELTA)
+IF (PRESENT(csubsec)) then
+   do isubsec = 1,nsubsec
+      tsubsec(isubsec) = COUNT(csubsec(:,isubsec)*scale_subsec(isubsec) .GT. 999.+EPS_DELTA)
+   enddo
+ENDIF
 td = COUNT(drydep(:)*scale_dry .GT. 999.+EPS_DELTA)
 tn = COUNT(wetdep(:)*scale_wet .GT. 999.+EPS_DELTA)
 !
@@ -139,10 +150,12 @@ ENDIF
 IF (ts .GT. (0.05*nrrcp + EPS_DELTA)) THEN
   scale_sec = scale_sec/10.
 ENDIF
-IF (PRESENT(cseccor)) THEN
-  IF (tg .GT. (0.05*nrrcp + EPS_DELTA)) THEN
-    scale_sec_cor = scale_sec_cor/10.
-  ENDIF
+IF (PRESENT(csubsec)) THEN
+   do isubsec = 1,nsubsec
+     IF (tsubsec(isubsec) .GT. (0.05*nrrcp + EPS_DELTA)) THEN
+        scale_subsec(isubsec) = scale_subsec(isubsec)/10.
+     ENDIF
+  enddo
 ENDIF
 IF (td .GT. (0.05*nrrcp + EPS_DELTA)) THEN
   scale_dry = scale_dry/10.

--- a/ops_scalefac.f90
+++ b/ops_scalefac.f90
@@ -53,34 +53,34 @@ PARAMETER        (ROUTINENAAM = 'ops_scalefac')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! number of receptor points
 INTEGER*4, INTENT(IN)                            :: nsubsec                    ! number sub-secondary species
-REAL*4,    INTENT(IN)                            :: cpri(nrrcp)                ! array van primaire concentraties
-REAL*4,    INTENT(IN)                            :: csec(nrrcp)                ! array van secundaire concentraties
-REAL*4,    INTENT(IN)                            :: drydep(nrrcp)              ! array van droge depositie
-REAL*4,    INTENT(IN)                            :: wetdep(nrrcp)              ! array van natte depositie
-REAL*4,    INTENT(IN), OPTIONAL                  :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary substance [ug/m3]
+real,      INTENT(IN)                            :: cpri(nrrcp)                ! array van primaire concentraties
+real,      INTENT(IN)                            :: csec(nrrcp)                ! array van secundaire concentraties
+real,      INTENT(IN)                            :: drydep(nrrcp)              ! array van droge depositie
+real,      INTENT(IN)                            :: wetdep(nrrcp)              ! array van natte depositie
+real,      INTENT(IN), OPTIONAL                  :: csubsec(nrrcp,nsubsec)     ! concentration of sub-secondary substance [ug/m3]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: scale_con                  ! schaal vergr. concentratie
-REAL*4,    INTENT(OUT)                           :: scale_sec                  ! schaal vergr. secundaire concentratie
-REAL*4,    INTENT(OUT)                           :: scale_dep                  ! schaal vergr. droge depositie
-REAL*4,    INTENT(OUT), OPTIONAL                 :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
+real,      INTENT(OUT)                           :: scale_con                  ! schaal vergr. concentratie
+real,      INTENT(OUT)                           :: scale_sec                  ! schaal vergr. secundaire concentratie
+real,      INTENT(OUT)                           :: scale_dep                  ! schaal vergr. droge depositie
+real,      INTENT(OUT), OPTIONAL                 :: scale_subsec(nsubsec)      ! scaling factor for sub-secondary species
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: i                          ! teller over schaalfactoren
 INTEGER*4                                        :: isubsec                    ! index of sub-secondary species
-REAL*4                                           :: cmax                       ! grootst voorkomende primaire concentratie
-REAL*4                                           :: csmax                      ! grootst voorkomende secundaire concentratie
-REAL*4                                           :: csubsecmax(nsubsec)        ! maximal value csubsec
-REAL*4                                           :: ddepmax                    ! grootst voorkomende droge depositie
-REAL*4                                           :: depntmax                   ! grootst voorkomende natte depositie
-REAL*4                                           :: s                          ! schaalfactor
-REAL*4                                           :: tc                         ! teller aantal te grote prim. conc.
-REAL*4                                           :: td                         ! teller aantal te grote droge dep.
-REAL*4                                           :: tn                         ! teller aantal te grote natte dep.
-REAL*4                                           :: ts                         ! teller aantal te grote sec. conc.
-REAL*4                                           :: tsubsec(nsubsec)                ! number of sub-secondary species with too large concentrations
-REAL*4                                           :: scale_dry                  ! schaal vergr. concentratie
-REAL*4                                           :: scale_wet                  ! schaal vergr. concentratie
+real                                             :: cmax                       ! grootst voorkomende primaire concentratie
+real                                             :: csmax                      ! grootst voorkomende secundaire concentratie
+real                                             :: csubsecmax(nsubsec)        ! maximal value csubsec
+real                                             :: ddepmax                    ! grootst voorkomende droge depositie
+real                                             :: depntmax                   ! grootst voorkomende natte depositie
+real                                             :: s                          ! schaalfactor
+real                                             :: tc                         ! teller aantal te grote prim. conc.
+real                                             :: td                         ! teller aantal te grote droge dep.
+real                                             :: tn                         ! teller aantal te grote natte dep.
+real                                             :: ts                         ! teller aantal te grote sec. conc.
+real                                             :: tsubsec(nsubsec)                ! number of sub-secondary species with too large concentrations
+real                                             :: scale_dry                  ! schaal vergr. concentratie
+real                                             :: scale_wet                  ! schaal vergr. concentratie
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_seccmp.f90
+++ b/ops_seccmp.f90
@@ -52,72 +52,72 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_seccmp')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary species emitted from source
-REAL*4,    INTENT(IN)                            :: ueff                       ! effective transport velocity of plume [m/s]
-REAL*4,    INTENT(IN)                            :: rcsec                      ! opp. weerstand sec. component
-REAL*4,    INTENT(IN)                            :: routsec                    ! in-cloud scavenging ratio for secondary component
-                                                                               ! (rout << rain-out = in-cloud) [-] 
-REAL*4,    INTENT(IN)                            :: ccc                        ! undepleted concentration including part above mixing layer; 
+real,      INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary species emitted from source
+real,      INTENT(IN)                            :: ueff                       ! effective transport velocity of plume [m/s]
+real,      INTENT(IN)                            :: rcsec                      ! opp. weerstand sec. component
+real,      INTENT(IN)                            :: routsec                    ! in-cloud scavenging ratio for secondary component
+                                                                               ! (rout << rain-out = in-cloud) [-]
+real,      INTENT(IN)                            :: ccc                        ! undepleted concentration including part above mixing layer;
                                                                                ! is needed for e.g. wet deposition.
-REAL*4,    INTENT(IN)                            :: vv                         ! total source depletion factor for primary component
-REAL*4,    INTENT(IN)                            :: amol1                      ! molgewicht primaire component
-REAL*4,    INTENT(IN)                            :: amol2                      ! molgewicht secundaire component
-REAL*4,    INTENT(IN)                            :: xvg                        ! factor not used; xvg = 1
-REAL*4,    INTENT(IN)                            :: sigz                       ! 
-REAL*4,    INTENT(IN)                            :: grad                       ! 
-REAL*4,    INTENT(IN)                            :: utr                        ! average wind speed over the trajectory (m/s)
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: xloc                       ! 
-REAL*4,    INTENT(IN)                            :: vw10                       ! 
-REAL*4,    INTENT(IN)                            :: pcoef                      ! 
-REAL*4,    INTENT(IN)                            :: virty                      ! 
-REAL*4,    INTENT(IN)                            :: regenk                     ! 
-REAL*4,    INTENT(IN)                            :: htot                       ! 
-REAL*4,    INTENT(IN)                            :: onder                      ! 
-REAL*4,    INTENT(IN)                            :: twt                        ! 
-REAL*4,    INTENT(IN)                            :: ri                         ! 
-REAL*4,    INTENT(IN)                            :: rb                         ! 
-REAL*4,    INTENT(IN)                            :: ra50                       ! 
-REAL*4,    INTENT(IN)                            :: cgt                        ! 
-REAL*4,    INTENT(IN)                            :: xvghbr                     ! 
-REAL*4,    INTENT(IN)                            :: xvglbr                     ! 
-REAL*4,    INTENT(IN)                            :: vnatpri                    ! 
-REAL*4,    INTENT(IN)                            :: vchem                      ! chemical conversion rate [%/h]
-REAL*4,    INTENT(IN)                            :: ra4_rcp                    ! 
-REAL*4,    INTENT(IN)                            :: ra50_rcp                   ! 
-REAL*4,    INTENT(IN)                            :: rb_rcp                     ! 
-REAL*4,    INTENT(IN)                            :: rc_sec_rcp                 ! 
-REAL*4,    INTENT(IN)                            :: ra50tra                    ! 
-REAL*4,    INTENT(IN)                            :: rb_tra                     ! 
+real,      INTENT(IN)                            :: vv                         ! total source depletion factor for primary component
+real,      INTENT(IN)                            :: amol1                      ! molgewicht primaire component
+real,      INTENT(IN)                            :: amol2                      ! molgewicht secundaire component
+real,      INTENT(IN)                            :: xvg                        ! factor not used; xvg = 1
+real,      INTENT(IN)                            :: sigz
+real,      INTENT(IN)                            :: grad
+real,      INTENT(IN)                            :: utr                        ! average wind speed over the trajectory (m/s)
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: xloc
+real,      INTENT(IN)                            :: vw10
+real,      INTENT(IN)                            :: pcoef
+real,      INTENT(IN)                            :: virty
+real,      INTENT(IN)                            :: regenk
+real,      INTENT(IN)                            :: htot
+real,      INTENT(IN)                            :: onder
+real,      INTENT(IN)                            :: twt
+real,      INTENT(IN)                            :: ri
+real,      INTENT(IN)                            :: rb
+real,      INTENT(IN)                            :: ra50
+real,      INTENT(IN)                            :: cgt
+real,      INTENT(IN)                            :: xvghbr
+real,      INTENT(IN)                            :: xvglbr
+real,      INTENT(IN)                            :: vnatpri
+real,      INTENT(IN)                            :: vchem                      ! chemical conversion rate [%/h]
+real,      INTENT(IN)                            :: ra4_rcp
+real,      INTENT(IN)                            :: ra50_rcp
+real,      INTENT(IN)                            :: rb_rcp
+real,      INTENT(IN)                            :: rc_sec_rcp
+real,      INTENT(IN)                            :: ra50tra
+real,      INTENT(IN)                            :: rb_tra
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: pr                         ! 
-REAL*4,    INTENT(OUT)                           :: vnatsec                    ! 
-REAL*4,    INTENT(OUT)                           :: cgtsec                     ! 
-REAL*4,    INTENT(OUT)                           :: vgsec                      ! deposition velocity secondary component [m/s[
-REAL*4,    INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary species [g/s]
-REAL*4,    INTENT(OUT)                           :: consec                     ! concentration secondary component [ug/m3]
-REAL*4,    INTENT(OUT)                           :: vg50trans                  ! 
+real,      INTENT(OUT)                           :: pr
+real,      INTENT(OUT)                           :: vnatsec
+real,      INTENT(OUT)                           :: cgtsec
+real,      INTENT(OUT)                           :: vgsec                      ! deposition velocity secondary component [m/s[
+real,      INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary species [g/s]
+real,      INTENT(OUT)                           :: consec                     ! concentration secondary component [ug/m3]
+real,      INTENT(OUT)                           :: vg50trans
 
 ! LOCAL VARIABLES
-REAL*4                                           :: a                          ! 
-REAL*4                                           :: diameter                   ! 
-REAL*4                                           :: h                          ! 
-REAL*4                                           :: hl                         ! 
-REAL*4                                           :: gradsec                    ! 
-REAL*4                                           :: qpri                       ! cross-wind integrated mass flux [g/s] of primary species of depleted source
+real                                             :: a
+real                                             :: diameter
+real                                             :: h
+real                                             :: hl
+real                                             :: gradsec
+real                                             :: qpri                       ! cross-wind integrated mass flux [g/s] of primary species of depleted source
 
-REAL*4                                           :: rcrs                       ! 
-REAL*4                                           :: s                          ! 
-REAL*4                                           :: sigzsec                    ! 
-REAL*4                                           :: vgsect                     ! 
-REAL*4                                           :: vnatrainv                  ! uitregensnelheid
-REAL*4                                           :: vnatwashv                  ! uitwassnelheid
-REAL*4                                           :: vw                         ! 
-REAL*4                                           :: qsec_uncorr                ! uncorrected qsec (from seccd)
-REAL*4                                           :: xg
+real                                             :: rcrs
+real                                             :: s
+real                                             :: sigzsec
+real                                             :: vgsect
+real                                             :: vnatrainv                  ! uitregensnelheid
+real                                             :: vnatwashv                  ! uitwassnelheid
+real                                             :: vw
+real                                             :: qsec_uncorr                ! uncorrected qsec (from seccd)
+real                                             :: xg
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -368,32 +368,32 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'seccd')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary species emitted from source
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: vw                         ! average wind speed over trajectory [m/s]
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: vgpri                      ! 
-REAL*4,    INTENT(IN)                            :: vnatpri                    ! loss rate due to wet deposition of primary component [%/h]
-REAL*4,    INTENT(IN)                            :: vchem                      ! chemical conversion rate [%/h]
-REAL*4,    INTENT(IN)                            :: vgsec                      ! 
-REAL*4,    INTENT(IN)                            :: vnatsec                    ! loss rate due to wet deposition of secondary component [%/h]
-REAL*4,    INTENT(IN)                            :: amol1                      ! molecular weight primary component
-REAL*4,    INTENT(IN)                            :: amol2                      ! molecular weight secondary component
-REAL*4,    INTENT(IN)                            :: diameter                   ! 
-REAL*4,    INTENT(IN)                            :: sigz                       ! 
+real,      INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary species emitted from source
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: vw                         ! average wind speed over trajectory [m/s]
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: vgpri
+real,      INTENT(IN)                            :: vnatpri                    ! loss rate due to wet deposition of primary component [%/h]
+real,      INTENT(IN)                            :: vchem                      ! chemical conversion rate [%/h]
+real,      INTENT(IN)                            :: vgsec
+real,      INTENT(IN)                            :: vnatsec                    ! loss rate due to wet deposition of secondary component [%/h]
+real,      INTENT(IN)                            :: amol1                      ! molecular weight primary component
+real,      INTENT(IN)                            :: amol2                      ! molecular weight secondary component
+real,      INTENT(IN)                            :: diameter
+real,      INTENT(IN)                            :: sigz
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: qpri                       ! cross-wind integrated mass flux of primary species at receptor [g/s]
-REAL*4,    INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary species at receptor [g/s]
+real,      INTENT(OUT)                           :: qpri                       ! cross-wind integrated mass flux of primary species at receptor [g/s]
+real,      INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary species at receptor [g/s]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: itim                       ! time step index
 INTEGER*4                                        :: ntim                       ! number of time steps
-REAL*4                                           :: a                          ! effective transport distance over which conversion takes place
-REAL*4                                           :: a1                         ! 
-REAL*4                                           :: b                          ! 
-REAL*4                                           :: dt                         ! length of time step [s]
+real                                             :: a                          ! effective transport distance over which conversion takes place
+real                                             :: a1
+real                                             :: b
+real                                             :: dt                         ! length of time step [s]
 integer                                          :: it                         ! iteration count
 integer, parameter                               :: nit = 10                   ! maximal number of iterations
 logical                                          :: converged                  ! iteration procedure for Q(it) has converged : abs(Q(it-1) = Q(it)) < epsa + epsr * Q(it)
@@ -409,8 +409,8 @@ real                                             :: loss_sec                   !
 real                                             :: e3_pri_sec                 ! factor in production term of secondary species = (Msec/Mpri) * delta_t * k_chem
 real                                             :: e1_pri                     ! source depletion factor for primary species, due to dry deposition, wet deposition and chemical conversion
 real                                             :: e1_sec                     ! source depletion factor for secondary species, due to dry deposition, wet deposition and chemical conversion
-REAL*4                                           :: xseg                       ! end point of plume segment [m]
-REAL*4                                           :: dx                         ! travelled distance during one time step = length of plume segment [m]
+real                                             :: xseg                       ! end point of plume segment [m]
+real                                             :: dx                         ! travelled distance during one time step = length of plume segment [m]
 logical                                          :: lfound_seg_depos           ! plume segment where deposition starts has been found
                                                                                
 ! SCCS-ID VARIABLES

--- a/ops_seccmp.f90
+++ b/ops_seccmp.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME           : %M%
@@ -24,10 +27,10 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM LLO
 ! LANGUAGE           : FORTRAN-77/90
-! DESCRIPTION        : Compute concentration of secondary component (SO4,NO3,NH4) and deposition velocities
+! DESCRIPTION        : Compute concentration of secondary component (SO4,NO3,NH4) 
 ! EXIT CODES         :
 ! FILES AND OTHER    :
 !    I/O DEVICES
@@ -40,6 +43,7 @@ SUBROUTINE ops_seccmp(qbpri, ueff, rcsec, routsec, ccc, vv, amol1, amol2, xvg, s
                    &  ra50_rcp, rb_rcp, rc_sec_rcp, pr, vnatsec, cgtsec, vgsec, qsec, consec, vg50trans, ra50tra, rb_tra, xg)
 
 USE m_commonconst
+USE m_ops_vchem
 
 IMPLICIT NONE
 
@@ -48,7 +52,7 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_seccmp')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary substance emitted from source
+REAL*4,    INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary species emitted from source
 REAL*4,    INTENT(IN)                            :: ueff                       ! effective transport velocity of plume [m/s]
 REAL*4,    INTENT(IN)                            :: rcsec                      ! opp. weerstand sec. component
 REAL*4,    INTENT(IN)                            :: routsec                    ! in-cloud scavenging ratio for secondary component
@@ -80,7 +84,7 @@ REAL*4,    INTENT(IN)                            :: cgt                        !
 REAL*4,    INTENT(IN)                            :: xvghbr                     ! 
 REAL*4,    INTENT(IN)                            :: xvglbr                     ! 
 REAL*4,    INTENT(IN)                            :: vnatpri                    ! 
-REAL*4,    INTENT(IN)                            :: vchem                      ! 
+REAL*4,    INTENT(IN)                            :: vchem                      ! chemical conversion rate [%/h]
 REAL*4,    INTENT(IN)                            :: ra4_rcp                    ! 
 REAL*4,    INTENT(IN)                            :: ra50_rcp                   ! 
 REAL*4,    INTENT(IN)                            :: rb_rcp                     ! 
@@ -93,7 +97,7 @@ REAL*4,    INTENT(OUT)                           :: pr                         !
 REAL*4,    INTENT(OUT)                           :: vnatsec                    ! 
 REAL*4,    INTENT(OUT)                           :: cgtsec                     ! 
 REAL*4,    INTENT(OUT)                           :: vgsec                      ! deposition velocity secondary component [m/s[
-REAL*4,    INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary substance [g/s]
+REAL*4,    INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary species [g/s]
 REAL*4,    INTENT(OUT)                           :: consec                     ! concentration secondary component [ug/m3]
 REAL*4,    INTENT(OUT)                           :: vg50trans                  ! 
 
@@ -103,7 +107,7 @@ REAL*4                                           :: diameter                   !
 REAL*4                                           :: h                          ! 
 REAL*4                                           :: hl                         ! 
 REAL*4                                           :: gradsec                    ! 
-REAL*4                                           :: qpri                       ! cross-wind integrated mass flux [g/s] of primary substance of depleted source
+REAL*4                                           :: qpri                       ! cross-wind integrated mass flux [g/s] of primary species of depleted source
 
 REAL*4                                           :: rcrs                       ! 
 REAL*4                                           :: s                          ! 
@@ -285,13 +289,13 @@ CALL seccd(qbpri, disx, radius, utr, xl, vg50trans, vnatpri, vchem, vgsect, vnat
         &  qsec)
 !
 ! In reality, we have to deal with variable mixing heigth and a transport speed that depends on emission height ->
-!  a correction is needed, using the 'exact' depletion factor for primary substance vv: 
+!  a correction is needed, using the 'exact' depletion factor for primary species vv: 
 !
-! vv      : total source depletion factor for primary substance
-! qbpri   : cross-wind integrated mass flux [g/s] of primary substance emitted from source
-! qbpri*vv: cross-wind integrated mass flux [g/s] of primary substance of depleted source, using 'exact' depletion factor vv
-! qpri    : cross-wind integrated mass flux [g/s] of primary substance of depleted source (numerical approximation from subroutine seccd)
-! qsec    : cross-wind integrated mass flux [g/s] of secondary substance (numerical approximation from subroutine seccd)
+! vv      : total source depletion factor for primary species
+! qbpri   : cross-wind integrated mass flux [g/s] of primary species emitted from source
+! qbpri*vv: cross-wind integrated mass flux [g/s] of primary species of depleted source, using 'exact' depletion factor vv
+! qpri    : cross-wind integrated mass flux [g/s] of primary species of depleted source (numerical approximation from subroutine seccd)
+! qsec    : cross-wind integrated mass flux [g/s] of secondary species (numerical approximation from subroutine seccd)
 ! 
 ! Correct qsec:
 !                qbpri*vv
@@ -302,9 +306,9 @@ CALL seccd(qbpri, disx, radius, utr, xl, vg50trans, vnatpri, vchem, vgsect, vnat
 !
 IF (qpri .GT. (0. + EPS_DELTA)) qsec = min(qbpri,(qsec*qbpri*vv)/qpri)
 !
-! Compute concentration of secondary substance 
+! Compute concentration of secondary species 
 !
-! 1. sigma_z < 1.6*xl -> in Gaussian plume OPS report 3.7, 3.15
+! 1. sigma_z < 1.6*xl -> in Gaussian plume OPS report 3.7, 3.15 FS
 !     
 !         q           q   NSEK            2                      -h^2            -(2z - h)^2          -(2z + h)^2
 ! csec = --- Dy Dz = --- -------- -------------------- [ exp(------------) + exp(------------) + exp(-------------) ]
@@ -317,14 +321,14 @@ IF (qpri .GT. (0. + EPS_DELTA)) qsec = min(qbpri,(qsec*qbpri*vv)/qpri)
 ! factor 1e6 for conversion g -> ug
 !
 ! 2. sigma_z > 1.6*xl (well mixed plume) AND depleted source strength > 1e-4*undepleted source strength
-!    assume that ratio of concentration and cross-wind integrated mass flux at the receptor is the same for primary and secondary substance:
+!    assume that ratio of concentration and cross-wind integrated mass flux at the receptor is the same for primary and secondary species:
 !
 !      csec   cpri            qsec        qsec   qbpri        qsec
 !      ---- = ----  -> csec = ---- cpri = -----  ----- cpri = ----- ccc,
 !      qsec   qpri            qpri        qbpri  qpri         qbpri 
 !
 !                                                              qbpri
-!      with ccc = undepleted concentration primary substance = ----- cpri
+!      with ccc = undepleted concentration primary species = ----- cpri
 !                                                              qpri
 !
 ! 3. sigma_z > 1.6*xl (well mixed plume) AND depleted source strength <= 1e-4*undepleted source strength -> (3.7, 3.9 OPS report)
@@ -351,18 +355,20 @@ CONTAINS
 
 !-------------------------------------------------------------------------------------------------------------------------------
 ! SUBROUTINE         : seccd
-! DESCRIPTION        : Compute cross-wind integrated mass fluxes for primary and secondary substances.
+! DESCRIPTION        : Compute cross-wind integrated mass fluxes Q for primary and secondary substances.
 !                      A numerical time stepping scheme is used here.
 !-------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE seccd(qbpri, disx, radius, vw, xl, vgpri, vnatpri, vchem, vgsec, vnatsec, amol1, amol2, diameter, sigz, qpri,       &
               &  qsec)
+
+IMPLICIT NONE
 
 ! CONSTANTS
 CHARACTER*512                                    :: ROUTINENAAM                ! 
 PARAMETER      (ROUTINENAAM = 'seccd')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary substance emitted from source
+REAL*4,    INTENT(IN)                            :: qbpri                      ! cross-wind integrated mass flux [g/s] of primary species emitted from source
 REAL*4,    INTENT(IN)                            :: disx                       ! 
 REAL*4,    INTENT(IN)                            :: radius                     ! 
 REAL*4,    INTENT(IN)                            :: vw                         ! average wind speed over trajectory [m/s]
@@ -378,28 +384,31 @@ REAL*4,    INTENT(IN)                            :: diameter                   !
 REAL*4,    INTENT(IN)                            :: sigz                       ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: qpri                       ! cross-wind integrated mass flux of primary substance of last time step (at receptor) [g/s]
-REAL*4,    INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary substance of last time step (at receptor) [g/s]
+REAL*4,    INTENT(OUT)                           :: qpri                       ! cross-wind integrated mass flux of primary species at receptor [g/s]
+REAL*4,    INTENT(OUT)                           :: qsec                       ! cross-wind integrated mass flux of secondary species at receptor [g/s]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: itim                       ! time step index
 INTEGER*4                                        :: ntim                       ! number of time steps
 REAL*4                                           :: a                          ! effective transport distance over which conversion takes place
 REAL*4                                           :: a1                         ! 
-REAL*4                                           :: amolv                      ! ratio of molecular weights secondary : primary component
 REAL*4                                           :: b                          ! 
 REAL*4                                           :: dt                         ! length of time step [s]
-REAL*4                                           :: dqsec                      ! amount of secondary component produced per time step
-REAL*4                                           :: depl_pri_wetdep_chem       ! depletion factor for primary substance due to wet deposition and chemical conversion
-REAL*4                                           :: depl_pri_drydep            ! depletion factor for primary substance due to dry deposition 
-REAL*4                                           :: e2                         ! 
-REAL*4                                           :: e3                         ! 
-REAL*4                                           :: qpri_prev                  ! cross-wind integrated mass flux of primary substance in previous time step [g/s] 
-REAL*4                                           :: qsec2                      ! alternative form for qsec 
-INTEGER                                          :: iopt                       ! option for method to compute qsec; 
-                                                                               ! iopt = 0 -> old method, 
-                                                                               ! iopt = 1 -> new version, which starts deposition after the plume hits the ground
-                                                                               ! iopt = 2 -> as iopt = 1 and 'midpoint' approximation of depletion of secondary substance
+integer                                          :: it                         ! iteration count
+integer, parameter                               :: nit = 10                   ! maximal number of iterations
+logical                                          :: converged                  ! iteration procedure for Q(it) has converged : abs(Q(it-1) = Q(it)) < epsa + epsr * Q(it)
+real, parameter                                  :: epsa = 0.001               ! absolute tolerance for iterative procedure (g/s)
+real                                             :: epsr = 0.01                ! relative tolerance for iterative procedure (-)
+real                                             :: qpri_prev_tim              ! cross-wind integrated mass flux of primary species at end of previous time step (g/s)
+real                                             :: qsec_prev_tim              ! cross-wind integrated mass flux of secondary species at end of previous time step (g/s)
+real                                             :: qpri_prev_it               ! cross-wind integrated mass flux of primary species at current time step, previous iteration (g/s)
+real                                             :: qsec_prev_it               ! cross-wind integrated mass flux of secondary species at current time step, previous iteration (g/s)
+real                                             :: loss_pri                   ! loss term of primary species (g/s)
+real                                             :: prod_sec                   ! production term of secondary species (g/s)
+real                                             :: loss_sec                   ! loss term of secondary species (g/s)
+real                                             :: e3_pri_sec                 ! factor in production term of secondary species = (Msec/Mpri) * delta_t * k_chem
+real                                             :: e1_pri                     ! source depletion factor for primary species, due to dry deposition, wet deposition and chemical conversion
+real                                             :: e1_sec                     ! source depletion factor for secondary species, due to dry deposition, wet deposition and chemical conversion
 REAL*4                                           :: xseg                       ! end point of plume segment [m]
 REAL*4                                           :: dx                         ! travelled distance during one time step = length of plume segment [m]
 logical                                          :: lfound_seg_depos           ! plume segment where deposition starts has been found
@@ -408,16 +417,10 @@ logical                                          :: lfound_seg_depos           !
 CHARACTER*81                                     :: sccsida                    ! 
 sccsida = '%W%:%E%'//char(0)
 !-------------------------------------------------------------------------------------------------------------------------------
-! Choose method:
-iopt = 0
 
-! Ratio of molecular weights of secondary and primary component:
-!
-amolv = amol2/amol1
-!
 ! Parameterisation of a = distance over which production of secondary species takes place; 
 ! a = x, point source; a = R*exp(-kt), inside area source; a = x - R*(1-exp(-kt)), outside area source.
-! Production takes place, where the concentration of the primary substance is > 0, hence
+! Production takes place, where the concentration of the primary species is > 0, hence
 ! the loss term b = exp(-k*t), with k = loss rate primary species (due to dry and wet deposition 
 ! and chemical conversion), t = travel time = radius/u = diameter/(2*u), u wind speed.
 ! The loss rate for dry deposition is k_dry_depos = vgpri/a1, a1 = effective plume thickness.
@@ -429,7 +432,7 @@ IF (radius .GT. (0. + EPS_DELTA)) THEN
    ELSE
       a1 = 1.5*sigz
    ENDIF
-   b = EXP( - (diameter/(vw*3.)*(vgpri/a1 + (vchem + vnatpri)/360000.)))
+   b = EXP( - (diameter/(vw*3.)*(vgpri/a1 + (vchem + vnatpri)/360000.)))  
    IF (disx .LE. (radius + EPS_DELTA)) THEN
       a = diameter/2.*b
    ELSE
@@ -441,7 +444,7 @@ ENDIF
 
 ! Set ntim = number of time steps; start with 6 time steps for each travel distance < 50 km
 ! and add 1 time step for each further 50 km: 
-ntim = NINT(a)/50000 + 6
+ntim = NINT(a)/50000 + 6 
 
 ! Set dt = length of time step [s]; end time = ntim*dt = a/wind_velocity
 ! and dx = distance travelled in one time step [m]
@@ -457,129 +460,96 @@ ntim = NINT(a)/50000 + 6
 dt = a/vw/ntim
 dx = dt*vw
 
-!
-! Initialise qpri_prev = cross-wind integrated mass flux of primary substance in previous time step [g/s] 
-!            qpri      = cross-wind integrated mass flux of primary substance in current time step [g/s]
-!            qsec      = cross-wind integrated mass flux of secondary substance up till current time step [g/s]
+! Initialise 
+!            qpri      = cross-wind integrated mass flux of primary species [g/s]
+!            qsec      = cross-wind integrated mass flux of secondary species [g/s]
 !            xseg      = end point of plume segment after each time step [m]
-qpri_prev = qbpri
-qpri      = qbpri
-qsec      = 0.
-qsec2     = 0.
-xseg      = 0.0 
-lfound_seg_depos = .false. ! segment where deposition starts has been found
+!     lfound_seg_depos = segment where deposition starts has been found
+qpri = qbpri
+qsec = 0.0
+xseg = 0.0 
+lfound_seg_depos = .false. 
+
 !
 ! factor 3.6e5 = 3600*100 conversion from %/h to 1/s
 !
 !    dC
-!   ---- = -k C --> C(t+dt) = C(t) exp(-k dt); k = k_drydep + k_chem + k_wetdep
+!   ---- = -k C --> C(t) = C(0) exp(-k t); k = k_drydep + k_chem + k_wetdep
 !    dt
-! Source depletion -> effect on C is translated into depleted source strength: Q(t+dt) = Q(t) exp(-k dt).
+! Source depletion -> effect on C is translated into depleted source strength: Q(t) = Q(0) exp(-k t).
 !
 ! k_drydep = conversion rate for dry deposition      = vgpri/xl           [1/s]
 ! k_wetdep = conversion rate for wet deposition      = vnatpri/(3600*100) [1/s]
 ! k_chem   = conversion rate for chemical conversion = vchem/(3600*100)   [1/s]
-! dt       = time step                                                    [s]
+! delta_t  = time step                               = dt                 [s]
+! 
+! In order to resolve the interdependency between the primary and secondary species, we use an extra iteration within
+! each time step. In tests, this iteration only needs 2-3 iterations to converge. 
 !
-! depl_pri_wetdep_chem = source depletion factor for primary substance, due to wet deposition and chemical conversion
-!    = EXP( -dt*(k_wetdep + k_chem)) 
-!    = EXP( -dt*(vnatpri + vchem)/3.6e5)
+! qpri          = cross-wind integrated mass flux of primary species at current time step, current iteration (g/s)
+! qpri_prev_tim = cross-wind integrated mass flux of primary species at end of previous time step (g/s)
+! qpri_prev_it  = cross-wind integrated mass flux of primary species at current time step, previous iteration (g/s)
+! qsec, qsec_prev_tim, qsec_prev_it: the same for secondary species
 !
-! depl_pri_drydep = source depletion factor for primary substance, due to dry deposition
-!    = EXP( -dt*k_drydep) 
-!    = EXP( -dt*vgpri/xl)
+! prod_sec   = production term of secondary species (g/s) = (Msec/Mpri) * (average mass primary) * k_chem = 
+!                                                         = (Msec/Mpri) * delta_t*(qpri_prev_tim + qpri)/2 * k_chem
+! e3_pri_sec = factor in production term of secondary species = (Msec/Mpri) * delta_t * k_chem
 !
-! e2 = 1 - source depletion factor for secondary substance, due to dry deposition and wet deposition
-!    = 1. - EXP( -dt*(k_drydep + k_wetdep))     
-!    = 1. - EXP( -dt*(vgsec/xl + vnatsec/3.6e5)) 
+! mass flux at start of time interval                                      : Q(t)
+! mass flux at end of time interval, after deposition, chemical conversion : Q(t+dt) = Q(t) exp(-k dt)
+! 
+! loss_pri = loss term of primary species (g/s) = Q(t) - Q(t+dt) = Q(t) [1 - exp(-k dt)], k = k_drydep + k_wetdep + k_chem;
+!            Q = qpri_prev_tim.
+! loss_sec = loss term of secondary species (g/s) = Q(t) - Q(t+dt) = Q(t) [1 - exp(-k dt)], k = k_drydep + k_wetdep + k_chem;
+!            Q is evaluated by means of a 'midpoint' apprimation: Q = (qsec_prev_tim + 0.5*prod_sec); this makes
+!            larger time steps possible.
 !
-! e3 = help variable for conversion of mass from primary to secondary substance [-] (see below); 
-!    = dt*(k_chem/2) 
-!    = dt*vchem/(3600*100*2) 
-!    = dt*vchem/7.2e+05 
-!
+! e1_pri = source depletion factor for primary species, due to dry deposition, wet deposition and chemical conversion
+!        = 1 - EXP( -delta_t*(k_drydep + k_wetdep + k_chem)) = 1 - EXP( -dt*(vgpri/xl + (vnatpri + vchem)/3.6e5))
+! e1_sec = source depletion factor for secondary species, due to dry deposition and wet deposition
+!        = 1 - EXP( -delta_t*(k_drydep + k_wetdep)) = 1 - EXP( -dt*(vgsec/xl + vnatsec/3.6e5))
 
-depl_pri_wetdep_chem = EXP( - dt*((vnatpri + vchem)/3.6e5))
-e2 = 1. - EXP( - dt*(vgsec/xl + vnatsec/3.6e5))
-e3 = dt*vchem/7.2e+05
-!
-! Loop over time steps
-!
+e1_pri = 1. - exp( - dt*(vgpri/xl + (vnatpri + vchem)/3.6e5));
+e1_sec = 1. - exp( - dt*(vgsec/xl +  vnatsec/3.6e5));
+e3_pri_sec = (amol2/amol1)*dt*vchem/3.6e+05;
+
+! Loop over time steps:
 DO itim = 1, ntim
-  
-   if (iopt .eq. 0) then
-      ! Old method: deposition for each time step:
-      depl_pri_drydep = exp( - dt*vgpri/xl)
-   else
 
-      ! New method; deposition starts at xg
+    ! Store mass fluxes of previous time step:
+    qpri_prev_tim = qpri
+    qsec_prev_tim = qsec
+    
+    ! Loop over iterations:
+    ! NOTE; iteration is only needed if we include both reactions NH3 -> NH4 and
+    ! NH4 -> NH3; if we use the net reaction NH3 -> NH4 only, we don't need an iteration.
+    ! 
+    !it = 0
+    !converged = .false.
+    !do while (it .lt. nit .and. .not. converged)
+    !    it = it + 1
+    
+        ! Store mass fluxes of previous iteration:
+        qpri_prev_it = qpri
+        qsec_prev_it = qsec
+        
+        ! Primary species:
+        loss_pri  = qpri_prev_tim*e1_pri
+        qpri      = qpri_prev_tim - loss_pri
+
+        ! Secondary species:
+        prod_sec = 0.5*(qpri_prev_tim + qpri)*e3_pri_sec
+        loss_sec = (qsec_prev_tim + 0.5*prod_sec)*e1_sec   
+        !loss_sec = (qsec_prev_tim - 0.5*prod_sec)*e1_sec   
+        qsec     = qsec_prev_tim + prod_sec - loss_sec
+
+        !! Check for convergence:
+        !converged = (abs(qpri - qpri_prev_it) .lt. epsa + epsr*qpri .and. abs(qsec - qsec_prev_it) .lt. epsa + epsr*qsec)
+	!! write(*,*) 'seccd: ',it,qpri,abs(qpri-qpri_prev_it),qsec,abs(qsec-qsec_prev_it)
+
+    !enddo ! loop over iterations
       
-      ! Update end point:
-      xseg = xseg + dx
-      
-      ! Check whether the plume has hit the ground (and deposition is going on):
-      if (xseg .le. xg) then
-         ! No deposition:
-         depl_pri_drydep = 1.0
-      else
-         if (.not. lfound_seg_depos) then
-            ! xseg > xg, so this is the first egment with deposition; deposition takes place not over the whole time step,
-            ! but over the time neede to travel from xg to xseg: (xseg - xg)/vw
-            lfound_seg_depos = .true.
-            depl_pri_drydep = exp( - ((xseg - xg)/vw)*vgpri/xl)
-         else
-            ! Deposition takes place over the whole segment:
-            depl_pri_drydep = exp( - dt*vgpri/xl)
-         endif
-      endif
-   endif
-      
-   ! Compute new depleted cross-wind integrated mass flux [g/s] for primary substance; Q(t+dt) = Q(t)*depl_pri_wetdep_chem*depl_pri_drydep:
-   qpri = qpri*depl_pri_wetdep_chem*depl_pri_drydep 
-
-   ! dqsec    = mass flux converted (due to chemical conversion) from primary to secondary substance, in the current time step [g/s];
-   ! qpri_prev       = mass flux of primary substance in previous time step [g/s]
-   ! qpri     = mass flux of primary substance in current time step [g/s]
-   ! mass_ave_pri = average mass of primary substance over time step = dt*(qpri + qpri_prev)/2  [g]
-   ! k_chem = conversion rate for chemical conversion = vchem/(3600*100)   [1/s]
-   ! mass converted = (Msec/Mpri) * mass_ave_pri * k_chem = (Msec/Mpri) * dt*(qpri+qpri_prev)/2 * k_chem =
-   !                = (Msec/Mpri) * (qpri+qpri_prev) * e3
-   dqsec = amolv*(qpri + qpri_prev)*e3
-
-   !-----------------------------------------------------------------------
-   ! Update cross-wind integrated mass flux for secondary substance
-   !-----------------------------------------------------------------------
-   ! In case we have no production, 
-   !    mass flux at start of time interval: Q(t) = qsec
-   !    mass flux at end of time interval, without deposition : Q(t)
-   !    mass flux at end of time interval, with deposition    : Q(t) exp(-k dt)
-   !    ------------------------------------------------------------------------
-   !    L = loss term due to deposition                       : Q(t) [1 - exp(-k dt)] =  Q(t) e2
-   !
-   ! In case we have a production term P (= dqsec = production from the primary component), we can make different choices at which point the factor e2 is used: 
-   ! A. L =  Q(t) e2       (depletion at old time step)
-   ! B. L = [Q(t)+P] e2    (depletion at new time step)
-   ! C. L = [Q(t)+ P/2] e2 (depletion at 'midpoint')
-   ! 
-   ! and this leads to:
-   !
-   ! A. Q(t+dt) =  Q(t) + P - L = Q(t) + P - Q(t) e2         =  qsec(1-e2) + dqsec
-   ! B. Q(t+dt) =  Q(t) + P - L = Q(t) + P - [Q(t)+P] e2     = (qsec + dqsec)(1-e2)
-   ! C. Q(t+dt) =  Q(t) + P - L = Q(t) + P - [Q(t)+ P/2] e2  =  qsec (1-e2) + dqsec (1-e2/2)
-   ! Original formula of Hans van Jaarsveld:                    qsec + dqsec - (qsec - dqsec/2.)*e2 
-   ! identical to original formula of Hans van Jaarsveld:       qsec (1-e2) + dqsec (1 + e2/2), which looks like C, apart from a - sign -> BUG ??
-
-   if (iopt .eq. 2) then
-      ! Midpoint approximation:
-      qsec = qsec*(1-e2) + dqsec*(1-0.5*e2)
-   else
-      ! Original method 
-      qsec = qsec + dqsec - (qsec - dqsec/2.)*e2 
-   endif
-
-   ! Save mass per second [g/s] of current time step of primary substance:
-   qpri_prev = qpri
-ENDDO
+ENDDO ! end loop over time steps
 
 RETURN
 END SUBROUTINE seccd

--- a/ops_src_char.f90
+++ b/ops_src_char.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME                 : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE     : %B% - %S%
 ! DATE - TIME          : %E% - %U%
 ! WHAT                 : %W%:%E%
-! AUTHOR               :
+! AUTHOR               : OPS-support 
 ! FIRM/INSTITUTE       : RIVM/LLO
 ! LANGUAGE             : FORTRAN-77/90
 ! USAGE                :

--- a/ops_src_char.f90
+++ b/ops_src_char.f90
@@ -54,14 +54,14 @@ PARAMETER    (ROUTINENAAM = 'ops_src_char')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 LOGICAL,   INTENT(IN)                            :: f_z0user                   ! user overwrites z0 values from meteo input
-REAL*4,    INTENT(IN)                            :: z0_user                    ! roughness length specified by the user [m]
+real,      INTENT(IN)                            :: z0_user                    ! roughness length specified by the user [m]
 INTEGER*4, INTENT(IN)                            :: xb                         ! x-coordinaat van huidige bron in buffer
 INTEGER*4, INTENT(IN)                            :: yb                         ! y-coordinaat van huidige bron in buffer
 TYPE (TApsGridInt), INTENT(IN)                   :: z0nlgrid                   ! map of roughness lengths in NL [m]
 TYPE (TApsGridInt), INTENT(IN)                   :: z0eurgrid                  ! map of roughness lengths in Europe [m]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(OUT)                           :: z0_src                     ! roughness length at source; from z0-map [m]
 TYPE (TError)                                    :: error  
 
 ! SCCS-ID VARIABLES

--- a/ops_stab_rek.f90
+++ b/ops_stab_rek.f90
@@ -60,72 +60,72 @@ PARAMETER      (ROUTINENAAM = 'ops_stab_rek')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: icm                        ! componentnummer
-REAL*4,    INTENT(IN)                            :: rb                         ! 
-REAL*4,    INTENT(IN)                            :: temp_C                     ! temperature at height zmet_T [C] 
-REAL*4,    INTENT(IN)                            :: h0                         ! 
-REAL*4,    INTENT(IN)                            :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
-REAL*4,    INTENT(IN)                            :: xl                         ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: qtr                        ! 
-REAL*4,    INTENT(IN)                            :: qrv                        ! 
+real,      INTENT(IN)                            :: rb
+real,      INTENT(IN)                            :: temp_C                     ! temperature at height zmet_T [C]
+real,      INTENT(IN)                            :: h0
+real,      INTENT(IN)                            :: z0_metreg_rcp              ! roughness length at receptor; interpolated from meteo regions [m]
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: z0_rcp                     ! roughness length at receptor; from z0-map [m]
+real,      INTENT(IN)                            :: xl
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: qtr
+real,      INTENT(IN)                            :: qrv
 INTEGER*4, INTENT(IN)                            :: dv                         ! 
-REAL*4,    INTENT(IN)                            :: ecvl(NSTAB, NTRAJ, *)      ! 
-REAL*4,    INTENT(IN)                            :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2] 
+real,      INTENT(IN)                            :: ecvl(NSTAB, NTRAJ, *)
+real,      INTENT(IN)                            :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2]
 INTEGER*4, INTENT(IN)                            :: ibtg                       ! 
-REAL*4,    INTENT(IN)                            :: uster_metreg_rcp           ! 
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: qww                        ! 
-REAL*4,    INTENT(IN)                            :: D_stack                    ! diameter of the stack [m]
-REAL*4,    INTENT(IN)                            :: V_stack                    ! exit velocity of plume at stack tip [m/s]
-REAL*4,    INTENT(IN)                            :: Ts_stack                   ! temperature of effluent from stack [K]
+real,      INTENT(IN)                            :: uster_metreg_rcp
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: qww
+real,      INTENT(IN)                            :: D_stack                    ! diameter of the stack [m]
+real,      INTENT(IN)                            :: V_stack                    ! exit velocity of plume at stack tip [m/s]
+real,      INTENT(IN)                            :: Ts_stack                   ! temperature of effluent from stack [K]
 LOGICAL,   INTENT(IN)                            :: emis_horizontal            ! horizontal outflow of emission
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
 INTEGER*4, INTENT(IN)                            :: itra                       ! 
-REAL*4,    INTENT(IN)                            :: qob                        ! 
-REAL*4,    INTENT(IN)                            :: xloc                       ! 
-REAL*4,    INTENT(IN)                            :: regenk                     ! 
-REAL*4,    INTENT(IN)                            :: ra4                        ! 
-REAL*4,    INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
-REAL*4,    INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
+real,      INTENT(IN)                            :: qob
+real,      INTENT(IN)                            :: xloc
+real,      INTENT(IN)                            :: regenk
+real,      INTENT(IN)                            :: ra4
+real,      INTENT(IN)                            :: z0_tra                     ! roughness length representative for trajectory [m]
+real,      INTENT(IN)                            :: z0_src                     ! roughness length at source; from z0-map [m]
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: ol_metreg_rcp                         ! Monin-Obukhov length
+real,      INTENT(INOUT)                         :: ol_metreg_rcp                         ! Monin-Obukhov length
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uster_rcp                  ! friction velocity at receptor; for z0 at receptor [m/s]
-REAL*4,    INTENT(OUT)                           :: ol_rcp                     ! Monin-Obukhov length at receptor; for z0 at receptor [m/s]
-REAL*4,    INTENT(OUT)                           :: uster_src                  ! friction velocity u* at source [m/s]
-REAL*4,    INTENT(OUT)                           :: ol_src                     ! Monin-Obukhov length at source [m]
-REAL*4,    INTENT(OUT)                           :: uster_tra                  ! friction velocity u*, trajectory averaged [m/s]
-REAL*4,    INTENT(OUT)                           :: ol_tra                     ! Monin-Obukhov length, trajectory averaged  [m]
-REAL*4,    INTENT(OUT)                           :: htot                       ! 
-REAL*4,    INTENT(OUT)                           :: htt                        ! 
-REAL*4,    INTENT(OUT)                           :: onder                      ! 
-REAL*4,    INTENT(OUT)                           :: uh                         ! 
-REAL*4,    INTENT(OUT)                           :: zu                         ! 
-REAL*4,    INTENT(OUT)                           :: qruim                      ! 
-REAL*4,    INTENT(OUT)                           :: qbron                      ! 
-REAL*4,    INTENT(OUT)                           :: dispg(NSTAB)               ! 
+real,      INTENT(OUT)                           :: uster_rcp                  ! friction velocity at receptor; for z0 at receptor [m/s]
+real,      INTENT(OUT)                           :: ol_rcp                     ! Monin-Obukhov length at receptor; for z0 at receptor [m/s]
+real,      INTENT(OUT)                           :: uster_src                  ! friction velocity u* at source [m/s]
+real,      INTENT(OUT)                           :: ol_src                     ! Monin-Obukhov length at source [m]
+real,      INTENT(OUT)                           :: uster_tra                  ! friction velocity u*, trajectory averaged [m/s]
+real,      INTENT(OUT)                           :: ol_tra                     ! Monin-Obukhov length, trajectory averaged  [m]
+real,      INTENT(OUT)                           :: htot
+real,      INTENT(OUT)                           :: htt
+real,      INTENT(OUT)                           :: onder
+real,      INTENT(OUT)                           :: uh
+real,      INTENT(OUT)                           :: zu
+real,      INTENT(OUT)                           :: qruim
+real,      INTENT(OUT)                           :: qbron
+real,      INTENT(OUT)                           :: dispg(NSTAB)
 
 ! LOCAL VARIABLES
-REAL*4                                           :: uster_metreg_from_rb_rcp   ! friction velocity at receptor from Rb(SO2); for z0 interpolated from meteo regions [m/s]
-REAL*4                                           :: ol_metreg_from_rb_rcp      ! Monin-Obukhov length at receptor from Rb(SO2); for z0 interpolated from meteo regions [m/s]
-REAL*4                                           :: dsx                        ! ratio disx/radius, i.e. 
+real                                             :: uster_metreg_from_rb_rcp   ! friction velocity at receptor from Rb(SO2); for z0 interpolated from meteo regions [m/s]
+real                                             :: ol_metreg_from_rb_rcp      ! Monin-Obukhov length at receptor from Rb(SO2); for z0 interpolated from meteo regions [m/s]
+real                                             :: dsx                        ! ratio disx/radius, i.e.
 !                                                                              ! (source-receptor distance)/(radius of area source)
-REAL*4                                           :: sz_rcp_stab_src            ! vertical dispersion coefficient sigma_z at receptor with (z0,u*,L,uh,zu) of source site 
-REAL*4                                           :: uh_rcp                     ! 
-REAL*4                                           :: zu_rcp                     ! 
-REAL*4                                           :: sz_rcp                     ! 
-REAL*4                                           :: qobb                       ! 
-REAL*4                                           :: qvk                        ! 
-REAL*4                                           :: qrvv                       ! 
-REAL*4                                           :: tcor                       ! 
-REAL*4                                           :: rcor                       ! 
-REAL*4                                           :: dncor                      ! 
-REAL*4                                           :: emf                        ! 
+real                                             :: sz_rcp_stab_src            ! vertical dispersion coefficient sigma_z at receptor with (z0,u*,L,uh,zu) of source site
+real                                             :: uh_rcp
+real                                             :: zu_rcp
+real                                             :: sz_rcp
+real                                             :: qobb
+real                                             :: qvk
+real                                             :: qrvv
+real                                             :: tcor
+real                                             :: rcor
+real                                             :: dncor
+real                                             :: emf
 logical                                          :: VsDs_opt                   ! read stack parameters Ds/Vs/Ts from source file
 
 ! SUBROUTINE AND FUNCTION CALLS

--- a/ops_statparexp.f90
+++ b/ops_statparexp.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Get parameters as windspeed, mixing height, frequency etc. from the meteo statistics as a function of
@@ -609,7 +612,7 @@ sccsida = '%W%:%E%'//char(0)
 ! Currently not averaged:
 ! wish for
 ! future version
-! (HvJ)
+! ( )
 ! no        1. number of hours for which a certain combination of classes has occurred [-]
 ! yes       3. wind speed (at 10 m height) [m/s]
 ! no        7. ratio effective dry deposition velocity over transport distance and average dry deposition velocity over transport distance for low sources [-]

--- a/ops_statparexp.f90
+++ b/ops_statparexp.f90
@@ -60,57 +60,57 @@ PARAMETER      (ROUTINENAAM = 'ops_statparexp')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: istab                       
-REAL*4,    INTENT(IN)                            :: hbron                       
-REAL*4,    INTENT(IN)                            :: qww    
-REAL*4,    INTENT(IN)                            :: D_stack                    ! diameter of the stack [m]
-REAL*4,    INTENT(IN)                            :: V_stack                    ! exit velocity of plume at stack tip [m/s]
-REAL*4,    INTENT(IN)                            :: Ts_stack                   ! temperature of effluent from stack [K]                     
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: qww
+real,      INTENT(IN)                            :: D_stack                    ! diameter of the stack [m]
+real,      INTENT(IN)                            :: V_stack                    ! exit velocity of plume at stack tip [m/s]
+real,      INTENT(IN)                            :: Ts_stack                   ! temperature of effluent from stack [K]
 LOGICAL,   INTENT(IN)                            :: emis_horizontal            ! horizontal outflow of emission
 INTEGER*4, INTENT(IN)                            :: iwd                         
-REAL*4,    INTENT(IN)                            :: radius                      
-REAL*4,    INTENT(IN)                            :: uurtot                      
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)  
-REAL*4,    INTENT(IN)                            :: trafst(NTRAJ)               
-REAL*4,    INTENT(IN)                            :: disx                       ! linear distance between source and receptor [m]                    
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: uurtot
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(IN)                            :: trafst(NTRAJ)
+real,      INTENT(IN)                            :: disx                       ! linear distance between source and receptor [m]
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
 
 ! SUBROUTINE ARGUMENTS - I/O
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: disxx                      ! effective travel distance between source and receptor [m]
+real,      INTENT(OUT)                           :: disxx                      ! effective travel distance between source and receptor [m]
 INTEGER*4, INTENT(OUT)                           :: isekt                      ! 
-REAL*4,    INTENT(OUT)                           :: vw10                       ! 
-REAL*4,    INTENT(OUT)                           :: aksek(12)                  ! 
-REAL*4,    INTENT(OUT)                           :: h0                         ! 
-REAL*4,    INTENT(OUT)                           :: hum                        ! 
-REAL*4,    INTENT(OUT)                           :: ol_metreg_rcp              ! 
-REAL*4,    INTENT(OUT)                           :: shear                      ! 
-REAL*4,    INTENT(OUT)                           :: rcaer                      ! 
-REAL*4,    INTENT(OUT)                           :: rcnh3                      ! 
-REAL*4,    INTENT(OUT)                           :: rcno2                      ! 
-REAL*4,    INTENT(OUT)                           :: temp_C                     ! temperature at height zmet_T [C]
-REAL*4,    INTENT(OUT)                           :: uster_metreg_rcp           ! 
-REAL*4,    INTENT(OUT)                           :: pcoef                      ! 
-REAL*4,    INTENT(OUT)                           :: htot                       ! 
-REAL*4,    INTENT(OUT)                           :: htt                        ! 
+real,      INTENT(OUT)                           :: vw10
+real,      INTENT(OUT)                           :: aksek(12)
+real,      INTENT(OUT)                           :: h0
+real,      INTENT(OUT)                           :: hum
+real,      INTENT(OUT)                           :: ol_metreg_rcp
+real,      INTENT(OUT)                           :: shear
+real,      INTENT(OUT)                           :: rcaer
+real,      INTENT(OUT)                           :: rcnh3
+real,      INTENT(OUT)                           :: rcno2
+real,      INTENT(OUT)                           :: temp_C                     ! temperature at height zmet_T [C]
+real,      INTENT(OUT)                           :: uster_metreg_rcp
+real,      INTENT(OUT)                           :: pcoef
+real,      INTENT(OUT)                           :: htot
+real,      INTENT(OUT)                           :: htt
 INTEGER*4, INTENT(OUT)                           :: itra                       ! 
-REAL*4,    INTENT(OUT)                           :: aant                       ! 
-REAL*4,    INTENT(OUT)                           :: xl                         ! 
-REAL*4,    INTENT(OUT)                           :: rb                         ! 
-REAL*4,    INTENT(OUT)                           :: ra4                        ! 
-REAL*4,    INTENT(OUT)                           :: ra50                       ! 
-REAL*4,    INTENT(OUT)                           :: xvglbr                     ! 
-REAL*4,    INTENT(OUT)                           :: xvghbr                     ! 
-REAL*4,    INTENT(OUT)                           :: xloc                       ! 
-REAL*4,    INTENT(OUT)                           :: xl100                      ! 
-REAL*4,    INTENT(OUT)                           :: rad                        ! 
-REAL*4,    INTENT(OUT)                           :: rcso2                      ! 
-REAL*4,    INTENT(OUT)                           :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2] 
-REAL*4,    INTENT(OUT)                           :: regenk                     ! 
-REAL*4,    INTENT(OUT)                           :: buil                       ! 
-REAL*4,    INTENT(OUT)                           :: rint                       ! 
-REAL*4,    INTENT(OUT)                           :: percvk                     ! 
+real,      INTENT(OUT)                           :: aant
+real,      INTENT(OUT)                           :: xl
+real,      INTENT(OUT)                           :: rb
+real,      INTENT(OUT)                           :: ra4
+real,      INTENT(OUT)                           :: ra50
+real,      INTENT(OUT)                           :: xvglbr
+real,      INTENT(OUT)                           :: xvghbr
+real,      INTENT(OUT)                           :: xloc
+real,      INTENT(OUT)                           :: xl100
+real,      INTENT(OUT)                           :: rad
+real,      INTENT(OUT)                           :: rcso2
+real,      INTENT(OUT)                           :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2]
+real,      INTENT(OUT)                           :: regenk
+real,      INTENT(OUT)                           :: buil
+real,      INTENT(OUT)                           :: rint
+real,      INTENT(OUT)                           :: percvk
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: is                         ! 
@@ -120,28 +120,28 @@ INTEGER*4                                        :: iss                        !
 INTEGER*4                                        :: itrx                       ! 
 INTEGER*4                                        :: iwdd                       ! 
 INTEGER*4                                        :: itraj                      ! index of distance class
-REAL*4                                           :: ccor                       ! concentration correction factor for area sources
-REAL*4                                           :: stt(NCOMP)                 ! 
-REAL*4                                           :: tal(NTRAJ)                 ! 
-REAL*4                                           :: dscor(NTRAJ)               ! 
-REAL*4                                           :: phi                        ! 
-REAL*4                                           :: r                          ! 
-REAL*4                                           :: r4                         ! 
-REAL*4                                           :: r50                        ! 
-REAL*4                                           :: s                          ! interpolation factor (0-1) for the contribution of wind sector is
-                                                                               ! (i.e. the second interpolation sector), to the wind direction 
-                                                                               ! from source to receptor  
-                                                                               
-REAL*4                                           :: s1(NTRAJ)                  ! interpolation factor for distance class (interpolates data between
+real                                             :: ccor                       ! concentration correction factor for area sources
+real                                             :: stt(NCOMP)
+real                                             :: tal(NTRAJ)
+real                                             :: dscor(NTRAJ)
+real                                             :: phi
+real                                             :: r
+real                                             :: r4
+real                                             :: r50
+real                                             :: s                          ! interpolation factor (0-1) for the contribution of wind sector is
+                                                                               ! (i.e. the second interpolation sector), to the wind direction
+                                                                               ! from source to receptor
+
+real                                             :: s1(NTRAJ)                  ! interpolation factor for distance class (interpolates data between
                                                                                ! lower and upper class boundary). Note that if ids is the class index
                                                                                ! where the source-receptor distance lies in, then 0 <= s1(ids) <= 1 and
                                                                                ! s1(i) = 0 for i /= ids
-                                                                               
-REAL*4                                           :: stta(NCOMP)                ! 
-REAL*4                                           :: sttr(NCOMP)                ! 
-REAL*4                                           :: sa                         ! 
-REAL*4                                           :: so                         ! 
-REAL*4                                           :: sp                         ! 
+
+real                                             :: stta(NCOMP)
+real                                             :: sttr(NCOMP)
+real                                             :: sa
+real                                             :: so
+real                                             :: sp
 real                                             :: dum                        ! dummy output variable
 
 ! SCCS-ID VARIABLES
@@ -341,16 +341,16 @@ PARAMETER      (ROUTINENAAM = 'bepafst')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: itra                       ! 
-REAL*4,    INTENT(IN)                            :: s(NTRAJ)                   ! 
-REAL*4,    INTENT(IN)                            :: trafst(NTRAJ)              ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! linear distance between source and receptor ('as the crow flies') [m]
+real,      INTENT(IN)                            :: s(NTRAJ)
+real,      INTENT(IN)                            :: trafst(NTRAJ)
+real,      INTENT(IN)                            :: disx                       ! linear distance between source and receptor ('as the crow flies') [m]
 
 ! SUBROUTINE ARGUMENTS - I/O
-REAL*4,    INTENT(INOUT)                         :: dscor(NTRAJ)               ! Note: dscor is not used anymore after this routine
-REAL*4,    INTENT(INOUT)                         :: xl                         ! 
+real,      INTENT(INOUT)                         :: dscor(NTRAJ)               ! Note: dscor is not used anymore after this routine
+real,      INTENT(INOUT)                         :: xl
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: disxx                      ! effective travel distance between source and receptor [m]
+real,      INTENT(OUT)                           :: disxx                      ! effective travel distance between source and receptor [m]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: ids                        ! 
@@ -446,27 +446,27 @@ END SUBROUTINE bepafst
 SUBROUTINE voorlpl(istab, isek, hbron, qww, astat, vw10, pcoef, htt)
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM                ! 
+CHARACTER*512                                    :: ROUTINENAAM
 PARAMETER      (ROUTINENAAM = 'voorlpl')
 
 ! CONSTANTS
-REAL*4                                           :: VWREP(NSTAB)               ! 
+real                                             :: VWREP(NSTAB)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
-REAL*4,    INTENT(IN)                            :: hbron                      ! 
-REAL*4,    INTENT(IN)                            :: qww                        ! 
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
+real,      INTENT(IN)                            :: hbron
+real,      INTENT(IN)                            :: qww
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: vw10                       ! 
-REAL*4,    INTENT(OUT)                           :: pcoef                      ! 
-REAL*4,    INTENT(OUT)                           :: htt                        ! 
+real,      INTENT(OUT)                           :: vw10
+real,      INTENT(OUT)                           :: pcoef
+real,      INTENT(OUT)                           :: htt
 
 ! LOCAL VARIABLES
-REAL*4                                           :: delh                       ! 
-REAL*4                                           :: utop                       ! 
+real                                             :: delh
+real                                             :: utop
 
 ! DATA
 DATA VWREP /2.6, 3.8, 4.0, 6.9, 1.4, 2.5/
@@ -550,24 +550,24 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ronafhpar')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: disxx                      ! 
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: disxx
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: s                          ! 
+real,      INTENT(IN)                            :: s
 INTEGER*4, INTENT(IN)                            :: isek                       ! middle of contributing wind sectors; note that ronafhpar
                                                                                ! is called with isek = isekt, i.e. the first of the two 
                                                                                ! interpolating wind sectors
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
-REAL*4,    INTENT(IN)                            :: s1(NTRAJ)                  ! 
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
+real,      INTENT(IN)                            :: s1(NTRAJ)
 INTEGER*4, INTENT(IN)                            :: ids                        ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: aksek(12)                  ! 
-REAL*4,    INTENT(OUT)                           :: sa                         ! 
-REAL*4,    INTENT(OUT)                           :: phi                        ! 
-REAL*4,    INTENT(OUT)                           :: so                         ! 
-REAL*4,    INTENT(OUT)                           :: stta(NCOMP)                ! 
-REAL*4,    INTENT(OUT)                           :: sttr(NCOMP)                ! 
+real,      INTENT(OUT)                           :: aksek(12)
+real,      INTENT(OUT)                           :: sa
+real,      INTENT(OUT)                           :: phi
+real,      INTENT(OUT)                           :: so
+real,      INTENT(OUT)                           :: stta(NCOMP)
+real,      INTENT(OUT)                           :: sttr(NCOMP)
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: i                          ! 
@@ -575,13 +575,13 @@ INTEGER*4                                        :: icomp                      !
 INTEGER*4                                        :: lpsek                      ! 
 INTEGER*4                                        :: jsek                       ! 
 INTEGER*4                                        :: scomp(14)                  ! 
-REAL*4                                           :: a                          ! 
-REAL*4                                           :: asek                       ! 
-REAL*4                                           :: statfactor                 ! 
-REAL*4                                           :: zz                         ! 
-REAL*4                                           :: p1                         ! 
-REAL*4                                           :: p2                         ! 
-REAL*4                                           :: pa                         ! 
+real                                             :: a
+real                                             :: asek
+real                                             :: statfactor
+real                                             :: zz
+real                                             :: p1
+real                                             :: p2
+real                                             :: pa
 
 ! DATA
 !     De arrayelementen uit de meteostatistiek die hier gebruikt worden.
@@ -758,24 +758,24 @@ PARAMETER      (ROUTINENAAM = 'windsek')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: htt                        ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
+real,      INTENT(IN)                            :: htt
+real,      INTENT(IN)                            :: disx
 INTEGER*4, INTENT(IN)                            :: iwd                        ! 
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: isekt                      ! 
-REAL*4,    INTENT(OUT)                           :: shear                      ! 
-REAL*4,    INTENT(OUT)                           :: htot                       ! 
+real,      INTENT(OUT)                           :: shear
+real,      INTENT(OUT)                           :: htot
 INTEGER*4, INTENT(OUT)                           :: iwdd                       ! 
 INTEGER*4, INTENT(OUT)                           :: iss                        ! 
 INTEGER*4, INTENT(OUT)                           :: is                         ! 
-REAL*4,    INTENT(OUT)                           :: s                          ! 
+real,      INTENT(OUT)                           :: s
 
 ! LOCAL VARIABLES
-REAL*4                                           :: alpha                      ! 
-REAL*4                                           :: sek                        ! 
+real                                             :: alpha
+real                                             :: sek
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -904,20 +904,20 @@ PARAMETER      (ROUTINENAAM = 'windcorr')
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: itra                       ! 
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
-REAL*4,    INTENT(IN)                            :: radius                     ! 
-REAL*4,    INTENT(IN)                            :: disx                       ! 
+real,      INTENT(IN)                            :: radius
+real,      INTENT(IN)                            :: disx
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
 INTEGER*4, INTENT(IN)                            :: iwdd                       ! 
 INTEGER*4, INTENT(IN)                            :: is                         ! 
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 
 ! SUBROUTINE ARGUMENTS - I/O
 INTEGER*4, INTENT(INOUT)                         :: iss                        ! 
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: ispecial                   ! 
-REAL*4,    INTENT(OUT)                           :: phi                        ! is not used as output
-REAL*4,    INTENT(OUT)                           :: s                          ! 
+real,      INTENT(OUT)                           :: phi                        ! is not used as output
+real,      INTENT(OUT)                           :: s
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: iwr                        ! 
@@ -1005,12 +1005,12 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'interp_ctr')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: disx                       ! 
-REAL*4,    INTENT(IN)                            :: trafst(NTRAJ)              ! 
+real,      INTENT(IN)                            :: disx
+real,      INTENT(IN)                            :: trafst(NTRAJ)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: itra                       ! 
-REAL*4,    INTENT(OUT)                           :: s(NTRAJ)                   ! 
+real,      INTENT(OUT)                           :: s(NTRAJ)
 INTEGER*4, INTENT(OUT)                           :: ids                        ! 
 
 ! LOCAL VARIABLES
@@ -1099,17 +1099,17 @@ PARAMETER      (ROUTINENAAM = 'interp_tra')
 
 ! SUBROUTINE ARGUMENTS - INPUT
 INTEGER*4, INTENT(IN)                            :: itra                       ! 
-REAL*4,    INTENT(IN)                            :: s(NTRAJ)                   ! 
+real,      INTENT(IN)                            :: s(NTRAJ)
 INTEGER*4, INTENT(IN)                            :: ids                        ! index element in s dat niet 0 is.
 INTEGER*4, INTENT(IN)                            :: istab                      ! 
 INTEGER*4, INTENT(IN)                            :: iss                        ! 
-REAL*4,    INTENT(IN)                            :: tal(NTRAJ)                 ! 
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
+real,      INTENT(IN)                            :: tal(NTRAJ)
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
 INTEGER*4, INTENT(OUT)                           :: itrx                       ! 
-REAL*4,    INTENT(OUT)                           :: aant                       ! 
-REAL*4,    INTENT(OUT)                           :: stt(NCOMP)                 ! 
+real,      INTENT(OUT)                           :: aant
+real,      INTENT(OUT)                           :: stt(NCOMP)
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: icomp                      ! 
@@ -1185,39 +1185,39 @@ INTEGER*4, INTENT(IN)                            :: istab                      !
 INTEGER*4, INTENT(IN)                            :: iss                        ! 
 INTEGER*4, INTENT(IN)                            :: itrx                       ! 
 INTEGER*4, INTENT(IN)                            :: is                         ! 
-REAL*4,    INTENT(IN)                            :: s                          ! 
+real,      INTENT(IN)                            :: s
 INTEGER*4, INTENT(IN)                            :: isek                       ! 
-REAL*4,    INTENT(IN)                            :: stt(NCOMP)                 ! 
-REAL*4,    INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK) ! 
+real,      INTENT(IN)                            :: stt(NCOMP)
+real,      INTENT(IN)                            :: astat(NTRAJ, NCOMP, NSTAB, NSEK)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: xl                         ! 
-REAL*4,    INTENT(OUT)                           :: vw10                       ! 
-REAL*4,    INTENT(OUT)                           :: rb                         ! 
-REAL*4,    INTENT(OUT)                           :: ra4                        ! 
-REAL*4,    INTENT(OUT)                           :: ra50                       ! 
-REAL*4,    INTENT(OUT)                           :: xvglbr                     ! 
-REAL*4,    INTENT(OUT)                           :: xvghbr                     ! 
-REAL*4,    INTENT(OUT)                           :: uster_metreg_rcp           ! 
-REAL*4,    INTENT(OUT)                           :: temp_C                     ! temperature at height zmet_T [C]
-REAL*4,    INTENT(OUT)                           :: ol_metreg_rcp              ! 
-REAL*4,    INTENT(OUT)                           :: h0                         ! 
-REAL*4,    INTENT(OUT)                           :: xloc                       ! 
-REAL*4,    INTENT(OUT)                           :: xl100                      ! 
-REAL*4,    INTENT(OUT)                           :: sp                         ! 
-REAL*4,    INTENT(OUT)                           :: rad                        ! 
-REAL*4,    INTENT(OUT)                           :: rcso2                      ! 
-REAL*4,    INTENT(OUT)                           :: hum                        ! 
-REAL*4,    INTENT(OUT)                           :: pcoef                      ! 
-REAL*4,    INTENT(OUT)                           :: rcnh3                      ! 
-REAL*4,    INTENT(OUT)                           :: rcno2                      ! 
-REAL*4,    INTENT(OUT)                           :: rcaer                      ! 
-REAL*4,    INTENT(OUT)                           :: buil                       ! 
-REAL*4,    INTENT(OUT)                           :: rint                       ! 
-REAL*4,    INTENT(OUT)                           :: shear                      ! 
-REAL*4,    INTENT(OUT)                           :: dscor(NTRAJ)               ! 
-REAL*4,    INTENT(OUT)                           :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2] 
-REAL*4,    INTENT(OUT)                           :: regenk                     ! 
+real,      INTENT(OUT)                           :: xl
+real,      INTENT(OUT)                           :: vw10
+real,      INTENT(OUT)                           :: rb
+real,      INTENT(OUT)                           :: ra4
+real,      INTENT(OUT)                           :: ra50
+real,      INTENT(OUT)                           :: xvglbr
+real,      INTENT(OUT)                           :: xvghbr
+real,      INTENT(OUT)                           :: uster_metreg_rcp
+real,      INTENT(OUT)                           :: temp_C                     ! temperature at height zmet_T [C]
+real,      INTENT(OUT)                           :: ol_metreg_rcp
+real,      INTENT(OUT)                           :: h0
+real,      INTENT(OUT)                           :: xloc
+real,      INTENT(OUT)                           :: xl100
+real,      INTENT(OUT)                           :: sp
+real,      INTENT(OUT)                           :: rad
+real,      INTENT(OUT)                           :: rcso2
+real,      INTENT(OUT)                           :: hum
+real,      INTENT(OUT)                           :: pcoef
+real,      INTENT(OUT)                           :: rcnh3
+real,      INTENT(OUT)                           :: rcno2
+real,      INTENT(OUT)                           :: rcaer
+real,      INTENT(OUT)                           :: buil
+real,      INTENT(OUT)                           :: rint
+real,      INTENT(OUT)                           :: shear
+real,      INTENT(OUT)                           :: dscor(NTRAJ)
+real,      INTENT(OUT)                           :: coef_space_heating         ! space heating coefficient (degree-day values in combination with a wind speed correction) [C m^1/2 / s^1/2]
+real,      INTENT(OUT)                           :: regenk
 
 ! DATA
 ! MENGH is default value for mixing height for 6 stability classes

--- a/ops_surface.f90
+++ b/ops_surface.f90
@@ -50,32 +50,32 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_surface')
 
 ! CONSTANTS
-REAL*4                                           :: K                          ! von Karman constant
+real                                             :: K                          ! von Karman constant
 PARAMETER   (K = 0.35)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z0                         ! roughness length (m)
-REAL*4,    INTENT(IN)                            :: zi                         ! mixing height (m)
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity (m)
-REAL*4,    INTENT(IN)                            :: h                          ! source heigth, including plume rise (m)
-REAL*4,    INTENT(IN)                            :: x                          ! downwind distance  (m)
+real,      INTENT(IN)                            :: z0                         ! roughness length (m)
+real,      INTENT(IN)                            :: zi                         ! mixing height (m)
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
+real,      INTENT(IN)                            :: uster                      ! friction velocity (m)
+real,      INTENT(IN)                            :: h                          ! source heigth, including plume rise (m)
+real,      INTENT(IN)                            :: x                          ! downwind distance  (m)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uh                         ! wind speed at downwind distance x and height zu [m/s]
-REAL*4,    INTENT(OUT)                           :: zu                         ! representative plume height, taking into account reflection 
+real,      INTENT(OUT)                           :: uh                         ! wind speed at downwind distance x and height zu [m/s]
+real,      INTENT(OUT)                           :: zu                         ! representative plume height, taking into account reflection
                                                                                ! at the top of the mixing layer and at the ground surface [m]
-REAL*4,    INTENT(OUT)                           :: szs                        ! vertical dispersion coefficient for surface layer [m]
+real,      INTENT(OUT)                           :: szs                        ! vertical dispersion coefficient for surface layer [m]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: iter                       ! 
 INTEGER*4                                        :: last                       ! 
-REAL*4                                           :: a                          ! 
-REAL*4                                           :: kz                         ! 
-REAL*4                                           :: phih                       ! 
-REAL*4                                           :: s                          ! 
-REAL*4                                           :: zw                         ! 
-REAL*4                                           :: zwold                      ! 
+real                                             :: a
+real                                             :: kz
+real                                             :: phih
+real                                             :: s
+real                                             :: zw
+real                                             :: zwold
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_surface.f90
+++ b/ops_surface.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : This routine calculates sigmaz in the surface layer (all stabilities) on the basis of Monin Obukhov

--- a/ops_tra_char.f90
+++ b/ops_tra_char.f90
@@ -60,10 +60,10 @@ PARAMETER    (ROUTINENAAM = 'ops_tra_char')
 INTEGER*4, INTENT(IN)                            :: icm                        ! 
 INTEGER*4, INTENT(IN)                            :: iopt_vchem                 ! option for chemical conversion rate (0 = old OPS, 1 = EMEP)
 LOGICAL,   INTENT(IN)                            :: f_z0user                   ! user overwrites z0 values from meteo input
-REAL*4,    INTENT(IN)                            :: z0_user                    ! roughness length specified by the user [m]
+real,      INTENT(IN)                            :: z0_user                    ! roughness length specified by the user [m]
 INTEGER*4, INTENT(IN)                            :: nrrcp                      ! aantal receptorpunten
-REAL*4,    INTENT(IN)                            :: x_rcp                      ! array met x-coordinaat van receptorpunten (RDM)
-REAL*4,    INTENT(IN)                            :: y_rcp                      ! array met y-coordinaat van receptorpunten (RDM)
+real,      INTENT(IN)                            :: x_rcp                      ! array met x-coordinaat van receptorpunten (RDM)
+real,      INTENT(IN)                            :: y_rcp                      ! array met y-coordinaat van receptorpunten (RDM)
 INTEGER*4, INTENT(IN)                            :: x_src                      ! array met x-coordinaat van bronnen in buffer
 INTEGER*4, INTENT(IN)                            :: y_src                      ! array met y-coordinaat van bronnen in buffer
 TYPE (TApsGridInt), INTENT(IN)                   :: lugrid                     ! land use grid
@@ -76,11 +76,11 @@ TYPE (Tvchem)      , INTENT(INOUT)               :: vchem2                     !
 LOGICAL,   INTENT(IN)                            :: domlu
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: z0_tra                     ! roughness length representative for trajectory [m] 
-REAL*4,    INTENT(OUT)                           :: lu_tra_per(NLU)            ! percentages of landuse classes over trajectorie (summed over intermediate points)
-REAL*4,    INTENT(OUT)                           :: so2bgtra                   ! 
-REAL*4,    INTENT(OUT)                           :: no2bgtra                   ! 
-REAL*4,    INTENT(OUT)                           :: nh3bgtra                   ! 
+real,      INTENT(OUT)                           :: z0_tra                     ! roughness length representative for trajectory [m]
+real,      INTENT(OUT)                           :: lu_tra_per(NLU)            ! percentages of landuse classes over trajectorie (summed over intermediate points)
+real,      INTENT(OUT)                           :: so2bgtra
+real,      INTENT(OUT)                           :: no2bgtra
+real,      INTENT(OUT)                           :: nh3bgtra
 TYPE (TError), INTENT(OUT)                       :: error                      ! error handling record
 
 ! LOCAL VARIABLES:

--- a/ops_vertdisp.f90
+++ b/ops_vertdisp.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE  : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : Calculation of vertical dispersion coefficient as a function of stability parameters and downwind distance

--- a/ops_vertdisp.f90
+++ b/ops_vertdisp.f90
@@ -50,29 +50,29 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_vertdisp')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z0                         ! roughness length (m)
-REAL*4,    INTENT(IN)                            :: zi                         ! mixing height (m)
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity (m)
-REAL*4,    INTENT(IN)                            :: hh                         ! source heigth, including plume rise (m)
-REAL*4,    INTENT(IN)                            :: x                          ! downwind distance  (m)
+real,      INTENT(IN)                            :: z0                         ! roughness length (m)
+real,      INTENT(IN)                            :: zi                         ! mixing height (m)
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
+real,      INTENT(IN)                            :: uster                      ! friction velocity (m)
+real,      INTENT(IN)                            :: hh                         ! source heigth, including plume rise (m)
+real,      INTENT(IN)                            :: x                          ! downwind distance  (m)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uh                         ! windspeed at downwind distance x and height zu (m/s)
-REAL*4,    INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection 
+real,      INTENT(OUT)                           :: uh                         ! windspeed at downwind distance x and height zu (m/s)
+real,      INTENT(OUT)                           :: zu                         ! representative plume height (m), taking into account reflection
                                                                                ! at the top of the mixing layer and at the ground surface
-REAL*4,    INTENT(OUT)                           :: sz                         ! vertical dispersion coefficient (m)
+real,      INTENT(OUT)                           :: sz                         ! vertical dispersion coefficient (m)
 
 TYPE (TError), INTENT(INOUT)                     :: error                      ! error handling record
 
 
 ! LOCAL VARIABLES
-REAL*4                                           :: h                          ! bronhoogte (m)
-REAL*4                                           :: szc                        ! convexe dispersie (m)
-REAL*4                                           :: szn                        ! neutrale dispersie
-REAL*4                                           :: szs                        ! oppervlakte dispersie
-REAL*4                                           :: fm                         ! 
-REAL*4                                           :: fs                         ! 
+real                                             :: h                          ! bronhoogte (m)
+real                                             :: szc                        ! convexe dispersie (m)
+real                                             :: szn                        ! neutrale dispersie
+real                                             :: szs                        ! oppervlakte dispersie
+real                                             :: fm
+real                                             :: fs
 
 ! SUBROUTINE AND FUNCTION CALLS
 EXTERNAL ops_surface

--- a/ops_virtdist.f90
+++ b/ops_virtdist.f90
@@ -46,11 +46,11 @@ USE m_commonconst
 IMPLICIT NONE
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: radius                     ! 
+real,      INTENT(IN)                            :: radius
 INTEGER*4, INTENT(IN)                            :: rond                       ! 
 
 ! RESULT
-REAL*4                                           :: ops_virtdist               ! 
+real                                             :: ops_virtdist
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_write_progress.f90
+++ b/ops_write_progress.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME                 : %M%
@@ -24,7 +27,7 @@
 ! BRANCH - SEQUENCE    : %B% - %S%
 ! DATE - TIME          : %E% - %U%
 ! WHAT                 : %W%:%E%
-! AUTHOR               :
+! AUTHOR               : OPS-support 
 ! FIRM/INSTITUTE       : RIVM/LLO
 ! LANGUAGE             : FORTRAN-77/90
 ! USAGE                :

--- a/ops_write_progress.f90
+++ b/ops_write_progress.f90
@@ -50,7 +50,7 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER    (ROUTINENAAM = 'ops_write_progress')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: progress                   ! percentage of progress reached
+real,      INTENT(IN)                            :: progress                   ! percentage of progress reached
 CHARACTER*(*), INTENT(IN)                        :: formatstring               ! formatstring for writing progress
 INTEGER*4, INTENT(IN)                            :: numbs                      ! number of characters which have to be backspaced
                                                                                ! in order to remain at the same position of the screen 

--- a/ops_wv_powerlaw.f90
+++ b/ops_wv_powerlaw.f90
@@ -1,25 +1,21 @@
-!-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
-!   National Institute of Public Health and Environment
-!           Laboratory for Air Research (RIVM/LLO)
-!                      The Netherlands
-!-------------------------------------------------------------------------------------------------------------------------------
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 subroutine ops_wv_powerlaw(istab,isek,astat,z,uz,vw10,pcoef)
 
-! Compute wind profile based on power law. Note that below the reference height of 10 m,
+! Compute wind profile based on power law. Note that below the reference height of 10 m, 
 ! the wind profile is assumed to be constant: uz(z < 10) = uz(z = 10).
 
 USE m_commonconst

--- a/ops_wvprofile.f90
+++ b/ops_wvprofile.f90
@@ -50,21 +50,21 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_wvprofile')
 
 ! CONSTANTS
-REAL*4                                           :: K                          ! von Karman constante
+real                                             :: K                          ! von Karman constante
 PARAMETER    (K = 0.4)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z0                         ! roughness length (m)
-REAL*4,    INTENT(IN)                            :: zu                         ! 
-REAL*4,    INTENT(IN)                            :: uster                      ! friction velocity (m)
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
+real,      INTENT(IN)                            :: z0                         ! roughness length (m)
+real,      INTENT(IN)                            :: zu
+real,      INTENT(IN)                            :: uster                      ! friction velocity (m)
+real,      INTENT(IN)                            :: ol                         ! Monin-Obukhov length  (m)
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uz                         ! wind velocity (m/s)
+real,      INTENT(OUT)                           :: uz                         ! wind velocity (m/s)
 
 ! LOCAL VARIABLES
-REAL*4                                           :: phim                       ! 
-REAL*4                                           :: y                          ! hulpvariabele voor berekening phim
+real                                             :: phim
+real                                             :: y                          ! hulpvariabele voor berekening phim
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_wvprofile.f90
+++ b/ops_wvprofile.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,7 +27,7 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
 ! DESCRIPTION        : This routine calculates the wind velocity at a certain height, assuming a logarithmic wind profile.

--- a/ops_z0corr.f90
+++ b/ops_z0corr.f90
@@ -53,30 +53,30 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'ops_z0corr')
 
 ! CONSTANTS
-REAL*4                                           :: C1                         ! 
-REAL*4                                           :: Z                          ! 
+real                                             :: C1
+real                                             :: Z
 PARAMETER   (C1  = 93500.) 
 PARAMETER   (Z   = 50.)
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: z01                        ! standard roughness length [m]
-REAL*4,    INTENT(IN)                            :: uster1                     ! friction velocity at standard roughness length 
-REAL*4,    INTENT(IN)                            :: ol1                        ! Monin-Obukhov length at standard roughness length [m]
-REAL*4,    INTENT(IN)                            :: z02                        ! new roughness length [m]
+real,      INTENT(IN)                            :: z01                        ! standard roughness length [m]
+real,      INTENT(IN)                            :: uster1                     ! friction velocity at standard roughness length
+real,      INTENT(IN)                            :: ol1                        ! Monin-Obukhov length at standard roughness length [m]
+real,      INTENT(IN)                            :: z02                        ! new roughness length [m]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uster2                     ! friction velocity at new roughness length 
-REAL*4,    INTENT(OUT)                           :: ol2                        ! Monin-Obukhov length at standard roughness length [m]
+real,      INTENT(OUT)                           :: uster2                     ! friction velocity at new roughness length
+real,      INTENT(OUT)                           :: ol2                        ! Monin-Obukhov length at standard roughness length [m]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: n                          ! iteration index
-REAL*4                                           :: h0                         ! 
-REAL*4                                           :: delta                      ! difference between old and new iterand for uster2
-REAL*4                                           :: phim                       ! 
-REAL*4                                           :: u50                        ! wind speed at 50 m height
-REAL*4                                           :: uold                       ! uster at previous iteration
-REAL*4                                           :: delta_old                  ! old difference between old and new iterand for uster2
-REAL*4                                           :: ur                         ! ratio uster/uold
+real                                             :: h0
+real                                             :: delta                      ! difference between old and new iterand for uster2
+real                                             :: phim
+real                                             :: u50                        ! wind speed at 50 m height
+real                                             :: uold                       ! uster at previous iteration
+real                                             :: delta_old                  ! old difference between old and new iterand for uster2
+real                                             :: ur                         ! ratio uster/uold
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 
@@ -185,14 +185,14 @@ CHARACTER*512                                    :: ROUTINENAAM                !
 PARAMETER      (ROUTINENAAM = 'stabcm')
 
 ! SUBROUTINE ARGUMENTS - INPUT
-REAL*4,    INTENT(IN)                            :: h                          ! hoogte
-REAL*4,    INTENT(IN)                            :: ol                         ! Monin Obukhovlengte
+real,      INTENT(IN)                            :: h                          ! hoogte
+real,      INTENT(IN)                            :: ol                         ! Monin Obukhovlengte
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: phim                       ! correctiefactor
+real,      INTENT(OUT)                           :: phim                       ! correctiefactor
 
 ! LOCAL VARIABLES
-REAL*4                                           :: y                          ! hulpvariabele voor berekening
+real                                             :: y                          ! hulpvariabele voor berekening
 
 ! SCCS-ID VARIABLES
 CHARACTER*81                                     :: sccsida                    ! 

--- a/ops_z0corr.f90
+++ b/ops_z0corr.f90
@@ -1,21 +1,24 @@
+!------------------------------------------------------------------------------------------------------------------------------- 
+! 
+! This program is free software: you can redistribute it and/or modify 
+! it under the terms of the GNU General Public License as published by 
+! the Free Software Foundation, either version 3 of the License, or 
+! (at your option) any later version. 
+! 
+! This program is distributed in the hope that it will be useful, 
+! but WITHOUT ANY WARRANTY; without even the implied warranty of 
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+! GNU General Public License for more details. 
+! 
+! You should have received a copy of the GNU General Public License 
+! along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+! 
 !-------------------------------------------------------------------------------------------------------------------------------
-! This program is free software: you can redistribute it and/or modify
-! it under the terms of the GNU General Public License as published by
-! the Free Software Foundation, either version 3 of the License, or
-! (at your option) any later version.
-!
-! This program is distributed in the hope that it will be useful,
-! but WITHOUT ANY WARRANTY; without even the implied warranty of
-! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
-!
-! You should have received a copy of the GNU General Public License
-! along with this program.  If not, see <http://www.gnu.org/licenses/>.
-!
-!                       Copyright (C) 2002 by
+!                       Copyright by
 !   National Institute of Public Health and Environment
 !           Laboratory for Air Research (RIVM/LLO)
 !                      The Netherlands
+!   No part of this software may be used, copied or distributed without permission of RIVM/LLO (2002)
 !
 ! SUBROUTINE
 ! NAME               : %M%
@@ -24,10 +27,10 @@
 ! BRANCH -SEQUENCE   : %B% - %S%
 ! DATE - TIME        : %E% - %U%
 ! WHAT               : %W%:%E%
-! AUTHOR             : HvJ/Franka Loeve (Cap Volmac)
+! AUTHOR             : OPS-support   
 ! FIRM/INSTITUTE     : RIVM/LLO
 ! LANGUAGE           : FORTRAN-77/90
-! DESCRIPTION        : Correct friction velocity (uster) and Monin-Obukhov length (ol) at a standard roughness length for a
+! DESCRIPTION        : Correct friction velocity (uster) and Monin-Obukhov length (ol) at a standard roughness length for a 
 !                      situation with another roughness length. The main assumption here is that the wind speed at 50 m height
 !                      is not influenced by the roughness of the surface. Temperature effects are not taken into account.
 !                      An iterative procedure is used: starting with uster1 compute a new uster2 and ol2 and continue the iteration,
@@ -46,40 +49,40 @@ USE m_commonconst
 IMPLICIT NONE
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM                !
+CHARACTER*512                                    :: ROUTINENAAM                ! 
 PARAMETER      (ROUTINENAAM = 'ops_z0corr')
 
 ! CONSTANTS
-REAL*4                                           :: C1                         !
-REAL*4                                           :: Z                          !
-PARAMETER   (C1  = 93500.)
+REAL*4                                           :: C1                         ! 
+REAL*4                                           :: Z                          ! 
+PARAMETER   (C1  = 93500.) 
 PARAMETER   (Z   = 50.)
 
 ! SUBROUTINE ARGUMENTS - INPUT
 REAL*4,    INTENT(IN)                            :: z01                        ! standard roughness length [m]
-REAL*4,    INTENT(IN)                            :: uster1                     ! friction velocity at standard roughness length
+REAL*4,    INTENT(IN)                            :: uster1                     ! friction velocity at standard roughness length 
 REAL*4,    INTENT(IN)                            :: ol1                        ! Monin-Obukhov length at standard roughness length [m]
 REAL*4,    INTENT(IN)                            :: z02                        ! new roughness length [m]
 
 ! SUBROUTINE ARGUMENTS - OUTPUT
-REAL*4,    INTENT(OUT)                           :: uster2                     ! friction velocity at new roughness length
+REAL*4,    INTENT(OUT)                           :: uster2                     ! friction velocity at new roughness length 
 REAL*4,    INTENT(OUT)                           :: ol2                        ! Monin-Obukhov length at standard roughness length [m]
 
 ! LOCAL VARIABLES
 INTEGER*4                                        :: n                          ! iteration index
-REAL*4                                           :: h0                         !
+REAL*4                                           :: h0                         ! 
 REAL*4                                           :: delta                      ! difference between old and new iterand for uster2
-REAL*4                                           :: phim                       !
+REAL*4                                           :: phim                       ! 
 REAL*4                                           :: u50                        ! wind speed at 50 m height
 REAL*4                                           :: uold                       ! uster at previous iteration
 REAL*4                                           :: delta_old                  ! old difference between old and new iterand for uster2
 REAL*4                                           :: ur                         ! ratio uster/uold
 
 ! SCCS-ID VARIABLES
-CHARACTER*81                                     :: sccsida                    !
+CHARACTER*81                                     :: sccsida                    ! 
 sccsida = '%W%:%E%'//char(0)
 !-------------------------------------------------------------------------------------------------------------------------------
-!
+! 
 !                        T rho_a cp (u*)^3
 ! (2.1) OPS report: L = -------------------
 !                         g H0 kappa
@@ -87,16 +90,16 @@ sccsida = '%W%:%E%'//char(0)
 !  rho_a : air density  = 1.292 kg/m3 (0 C), 1.247 kg/m3 (20 C), 1.204 kg/m3 (20 C), pressure = 1 atm
 !  cp    : specific heat capacity = 1003.5 J/(kg K), sea level, dry, T=0 C; 1012 J/(kg/K), typical room conditions (T = 23 C)
 !  kappa : von Karman constant = 0.4 [-]
-!  g     : accelaration of gravity = 9.81 m/s2
+!  g     : accelaration of gravity = 9.81 m/s2 
 !  T     : absolute temperature [K]
 !  H0    : surface heat flux [W/m2]
 !
-!                          T rho_a cp (u*)^3    T rho_a cp  (u*)^3       (u*)^3
+!                          T rho_a cp (u*)^3    T rho_a cp  (u*)^3       (u*)^3                               
 ! From this follows: H0  = ----------------- = ------------ ------ =  C1 ------
-!                           g L kappa            g kappa      L            L
+!                           g L kappa            g kappa      L            L                                  
 !
 !           T rho_a cp       K kg J s2       kg m2 s2     kg
-! [C1] = [ ------------ ] = ------------- = --------- = ------     (J = kg m2/s2)
+! [C1] = [ ------------ ] = ------------- = --------- = ------     (J = kg m2/s2) 
 !            g kappa         m3 kg K m       s2 m4        m2
 !
 ! actual values in code: rho = 1.29 kg/m3, cp = 1005 J/(kg K), kappa=0.4, g=9.81 m/s2, T=283 K; c1=rho*cp*T/(kappa*g) = 93467 kg/m2.
@@ -143,13 +146,13 @@ IF (ABS(z01 - z02) .GE. (0.1*z01 - EPS_DELTA)) THEN
       h0 = h0*ur**0.1
    ENDIF
 
-   ! If percentual difference of iterands > 1.5% AND number of iterations < 40 -> continue iteration
+   ! If percentual difference of iterands > 1.5% AND number of iterations < 40 -> continue iteration 
    IF ((delta .GT. (0.015*uster2 + EPS_DELTA)) .AND. (n .LT. 40)) THEN
       GOTO 50
    ENDIF
 
 ! Converged OR number of iterations >= 40;
-! limit L, u* such that
+! limit L, u* such that 
 ! -5 < L < 0 -> L = -5
 !  0 < L < 5 -> L =  5
 !  u* >= 0.06 m/s
@@ -178,7 +181,7 @@ CONTAINS
 SUBROUTINE stabcm(h, ol, phim)
 
 ! CONSTANTS
-CHARACTER*512                                    :: ROUTINENAAM                !
+CHARACTER*512                                    :: ROUTINENAAM                ! 
 PARAMETER      (ROUTINENAAM = 'stabcm')
 
 ! SUBROUTINE ARGUMENTS - INPUT
@@ -192,7 +195,7 @@ REAL*4,    INTENT(OUT)                           :: phim                       !
 REAL*4                                           :: y                          ! hulpvariabele voor berekening
 
 ! SCCS-ID VARIABLES
-CHARACTER*81                                     :: sccsida                    !
+CHARACTER*81                                     :: sccsida                    ! 
 sccsida = '%W%:%E%'//char(0)
 !-------------------------------------------------------------------------------------------------------------------------------
 IF (ol .GT. (0. + EPS_DELTA)) THEN


### PR DESCRIPTION
The code of 5.0 contains lots of (historical?) uses both `real` as well as `real*4` intensively, whereas unique use of solely `real` is more applicable for portability.

This pull request replaces remaining uses of `REAL*4`  to `real`, removing some hurdles for members of Dutch society to contribute.