### PR TITLE
Achieve up to double processing throughput (many sources, few receptors)

### DIFF
--- a/ops_read_emis.f90
+++ b/ops_read_emis.f90
@@ -132,7 +132,8 @@ IF (.NOT.sysopen(fu_bron, brnam, 'r', 'emission file', error)) GOTO 9999
 !
 ! Open scratch file
 !
-OPEN(fu_scratch, STATUS = 'SCRATCH')
+
+OPEN(fu_scratch, STATUS = 'SCRATCH', FORM = 'UNFORMATTED')
 
 !
 ! Read, select and check sources 

--- a/ops_read_source.f90
+++ b/ops_read_source.f90
@@ -103,7 +103,6 @@ type(Tbuilding)                                  :: building                   !
 LOGICAL                                          :: check_psd                  ! check whether particle size distribution has been read
 
 !-------------------------------------------------------------------------------------------------------------------------------
- 50 FORMAT (i4, 2f9.0, es12.3, f9.3, f6.1, f8.0, f6.1, 3e12.5, l2, 4i4, 4f9.3) ! format for writing to scratch (RDM; includes D_stack, V_stack, Ts_stack, building parameters, possibly -999). Also possible -999 for qw
 
 ! Initialisation:
 end_of_file = .FALSE.
@@ -139,7 +138,7 @@ DO WHILE (.NOT. end_of_file)
          category_selected = any((catsel(1:ncatsel)   .eq. 0) .OR. (ibroncat .eq. catsel(1:ncatsel)))
          
          IF (country_selected .AND. category_selected) THEN
-            WRITE (fu_scratch, 50) mm,x,y,qob,qww, hbron, diameter, szopp, D_stack, V_stack, Ts_stack, emis_horizontal, ibtg, ibroncat, iland, idgr, building%length, building%width, building%height, building%orientation
+            WRITE (fu_scratch) mm, x, y, qob, qww, hbron, diameter, szopp, D_stack, V_stack, Ts_stack, emis_horizontal, ibtg, ibroncat, iland, idgr, building%length, building%width, building%height, building%orientation
             numbron = numbron+1
          ENDIF
       ENDIF


### PR DESCRIPTION
A temporary file is switched from formatted to unformatted. Throughput increase will be less in scenarios as the number of receptors evaluated increases, but a performance improvement remains.

Change developed by Gerard Cats.